### PR TITLE
fix: go tip seems to be more careful with some castings

### DIFF
--- a/atmcfg/randgen.go
+++ b/atmcfg/randgen.go
@@ -37,7 +37,7 @@ func generateRandomASCIIString(length int) (string, error) {
 		// Make sure that the number/byte/letter is inside
 		// the range of printable ASCII characters (excluding space and DEL)
 		if n > 64 && n < asciiMax {
-			result += string(n)
+			result += string(rune(n))
 		}
 	}
 }

--- a/atmcfg/randgen_test.go
+++ b/atmcfg/randgen_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atmcfg
+
+import "testing"
+
+func TestGenerateRandomBase64String(t *testing.T) {
+	r, err := generateRandomASCIIString(20)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(r) != 20 {
+		t.Errorf("wrong length, got=%d", len(r))
+	}
+}

--- a/opsmngr/deployments.go
+++ b/opsmngr/deployments.go
@@ -1,3 +1,17 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package opsmngr
 
 import (

--- a/opsmngr/diagnostics_test.go
+++ b/opsmngr/diagnostics_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package opsmngr
 
 import (


### PR DESCRIPTION
## Proposed changes

I just spotted this, we don't block PRs if we fail on go master so that's probably why we did not know bit it looks like go1.15 may had broken the client

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

