### PR TITLE
CLOUDP-70161: add IAM users to client

### DIFF
--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -48,6 +48,7 @@ type Client struct {
 
 	Organizations          OrganizationsService
 	Projects               ProjectsService
+	Users                  UsersService
 	Automation             AutomationService
 	UnauthUsers            UnauthUsersService
 	AlertConfigurations    atlas.AlertConfigurationsService
@@ -96,6 +97,7 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c.Organizations = &OrganizationsServiceOp{Client: c}
 	c.Projects = &ProjectsServiceOp{Client: c}
+ 	c.Users = &UsersServiceOp{Client: c}
 	c.Automation = &AutomationServiceOp{Client: c}
 	c.AlertConfigurations = &atlas.AlertConfigurationsServiceOp{Client: c}
 	c.UnauthUsers = &UnauthUsersServiceOp{Client: c}

--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -97,7 +97,7 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c.Organizations = &OrganizationsServiceOp{Client: c}
 	c.Projects = &ProjectsServiceOp{Client: c}
- 	c.Users = &UsersServiceOp{Client: c}
+	c.Users = &UsersServiceOp{Client: c}
 	c.Automation = &AutomationServiceOp{Client: c}
 	c.AlertConfigurations = &atlas.AlertConfigurationsServiceOp{Client: c}
 	c.UnauthUsers = &UnauthUsersServiceOp{Client: c}

--- a/opsmngr/organizations.go
+++ b/opsmngr/organizations.go
@@ -69,7 +69,6 @@ func (s *OrganizationsServiceOp) List(ctx context.Context, opts *atlas.ListOptio
 	return root, resp, nil
 }
 
-
 // ListUsers gets all users in an organization.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/organization-get-all-users/

--- a/opsmngr/organizations.go
+++ b/opsmngr/organizations.go
@@ -31,6 +31,7 @@ const (
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/
 type OrganizationsService interface {
 	List(context.Context, *atlas.ListOptions) (*atlas.Organizations, *atlas.Response, error)
+	ListUsers(context.Context, string, *atlas.ListOptions) ([]*User, *atlas.Response, error)
 	Get(context.Context, string) (*atlas.Organization, *atlas.Response, error)
 	Projects(context.Context, string, *atlas.ListOptions) (*Projects, *atlas.Response, error)
 	Create(context.Context, *atlas.Organization) (*atlas.Organization, *atlas.Response, error)
@@ -66,6 +67,36 @@ func (s *OrganizationsServiceOp) List(ctx context.Context, opts *atlas.ListOptio
 	}
 
 	return root, resp, nil
+}
+
+
+// ListUsers gets all users in an organization.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/organization-get-all-users/
+func (s *OrganizationsServiceOp) ListUsers(ctx context.Context, orgID string, opts *atlas.ListOptions) ([]*User, *atlas.Response, error) {
+	path := fmt.Sprintf(orgUsersBasePath, orgID)
+
+	path, err := setQueryParams(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(UsersResponse)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Results, resp, nil
 }
 
 // Get gets a single organization.

--- a/opsmngr/organizations_test.go
+++ b/opsmngr/organizations_test.go
@@ -97,7 +97,6 @@ func TestOrganizations_GetAllOrganizations(t *testing.T) {
 	}
 }
 
-
 func TestOrganizations_ListUsers(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
@@ -158,26 +157,26 @@ func TestOrganizations_ListUsers(t *testing.T) {
 			FirstName:    "John",
 			ID:           "59db8d1d87d9d6420df0613a",
 			LastName:     "Smith",
-			Links: []*mongodbatlas.Link{},
-			Roles:        []*UserRole{
+			Links:        []*mongodbatlas.Link{},
+			Roles: []*UserRole{
 				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
 				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
 				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
 			},
-			Username:     "someone@example.com",
+			Username: "someone@example.com",
 		},
 		{
 			EmailAddress: "someone_else@example.com",
 			FirstName:    "Jill",
 			ID:           "59db8d1d87d9d6420df0613a",
 			LastName:     "Smith",
-			Links: []*mongodbatlas.Link{},
-			Roles:        []*UserRole{
+			Links:        []*mongodbatlas.Link{},
+			Roles: []*UserRole{
 				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
 				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
 				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
 			},
-			Username:     "someone@example.com",
+			Username: "someone@example.com",
 		},
 	}
 

--- a/opsmngr/organizations_test.go
+++ b/opsmngr/organizations_test.go
@@ -23,6 +23,8 @@ import (
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
+const orgID = "5a0a1e7e0f2912c554081adc"
+
 func TestOrganizations_GetAllOrganizations(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
@@ -95,7 +97,94 @@ func TestOrganizations_GetAllOrganizations(t *testing.T) {
 	}
 }
 
-const orgID = "5a0a1e7e0f2912c554081adc"
+
+func TestOrganizations_ListUsers(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/%s/%s/users", orgsBasePath, orgID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+			"links": [{
+				"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/users",
+				"rel": "self"
+			}],
+			"results": [{
+			   "emailAddress": "someone@example.com",
+			   "firstName": "John",
+			   "id": "59db8d1d87d9d6420df0613a",
+			   "lastName": "Smith",
+			   "links": [],
+			   "roles": [{
+				 "groupId": "59ea02e087d9d636b587a967",
+				 "roleName": "GROUP_OWNER"
+			   }, {
+				 "groupId": "59db8d1d87d9d6420df70902",
+				 "roleName": "GROUP_OWNER"
+			   }, {
+				 "orgId": "59db8d1d87d9d6420df0613f",
+				 "roleName": "ORG_OWNER"
+			   }],
+			   "username": "someone@example.com"
+			}, {
+			   "emailAddress": "someone_else@example.com",
+			   "firstName": "Jill",
+			   "id": "59db8d1d87d9d6420df0613a",
+			   "lastName": "Smith",
+			   "links": [],
+			   "roles": [{
+				 "groupId": "59ea02e087d9d636b587a967",
+				 "roleName": "GROUP_OWNER"
+			   }, {
+				 "groupId": "59db8d1d87d9d6420df70902",
+				 "roleName": "GROUP_OWNER"
+			   }, {
+				 "orgId": "59db8d1d87d9d6420df0613f",
+				 "roleName": "ORG_OWNER"
+			   }],
+			   "username": "someone@example.com"
+			}]
+		},`)
+	})
+
+	orgs, _, err := client.Organizations.ListUsers(ctx, orgID, nil)
+	if err != nil {
+		t.Fatalf("Organizations.ListUsers returned error: %v", err)
+	}
+
+	expected := []*User{
+		{
+			EmailAddress: "someone@example.com",
+			FirstName:    "John",
+			ID:           "59db8d1d87d9d6420df0613a",
+			LastName:     "Smith",
+			Links: []*mongodbatlas.Link{},
+			Roles:        []*UserRole{
+				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+			},
+			Username:     "someone@example.com",
+		},
+		{
+			EmailAddress: "someone_else@example.com",
+			FirstName:    "Jill",
+			ID:           "59db8d1d87d9d6420df0613a",
+			LastName:     "Smith",
+			Links: []*mongodbatlas.Link{},
+			Roles:        []*UserRole{
+				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+			},
+			Username:     "someone@example.com",
+		},
+	}
+
+	if diff := deep.Equal(orgs, expected); diff != nil {
+		t.Error(diff)
+	}
+}
 
 func TestOrganizations_Get(t *testing.T) {
 	client, mux, teardown := setup()

--- a/opsmngr/projects.go
+++ b/opsmngr/projects.go
@@ -117,7 +117,7 @@ func (s *ProjectsServiceOp) List(ctx context.Context, opts *atlas.ListOptions) (
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/get-all-users-in-one-group/
 func (s *ProjectsServiceOp) ListUsers(ctx context.Context, projectID string, opts *atlas.ListOptions) ([]*User, *atlas.Response, error) {
-	path := fmt.Sprintf(projectUsersBasePath, projectID)
+	path := fmt.Sprintf("%s/%s/users", projectBasePath, projectID)
 
 	path, err := setQueryParams(path, opts)
 	if err != nil {
@@ -244,7 +244,7 @@ func (s *ProjectsServiceOp) RemoveUser(ctx context.Context, projectID, userID st
 		return nil, atlas.NewArgError("userID", "must be set")
 	}
 
-	basePath := fmt.Sprintf("%s/%s", projectUsersBasePath, userID)
+	basePath := fmt.Sprintf("%s/%s/users/%s", projectBasePath, projectID, userID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, basePath, nil)
 	if err != nil {

--- a/opsmngr/projects.go
+++ b/opsmngr/projects.go
@@ -31,10 +31,12 @@ const (
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/
 type ProjectsService interface {
 	List(context.Context, *atlas.ListOptions) (*Projects, *atlas.Response, error)
+	ListUsers(context.Context, string, *atlas.ListOptions) ([]*User, *atlas.Response, error)
 	Get(context.Context, string) (*Project, *atlas.Response, error)
 	GetByName(context.Context, string) (*Project, *atlas.Response, error)
 	Create(context.Context, *Project) (*Project, *atlas.Response, error)
 	Delete(context.Context, string) (*atlas.Response, error)
+	RemoveUser(context.Context, string, string) (*atlas.Response, error)
 }
 
 // ProjectsServiceOp provides an implementation of the ProjectsService interface
@@ -109,6 +111,35 @@ func (s *ProjectsServiceOp) List(ctx context.Context, opts *atlas.ListOptions) (
 	}
 
 	return root, resp, nil
+}
+
+// ListUsers gets all users in a project.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/get-all-users-in-one-group/
+func (s *ProjectsServiceOp) ListUsers(ctx context.Context, projectID string, opts *atlas.ListOptions) ([]*User, *atlas.Response, error) {
+	path := fmt.Sprintf(projectUsersBasePath, projectID)
+
+	path, err := setQueryParams(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(UsersResponse)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Results, resp, nil
 }
 
 // Get gets a single project.
@@ -190,6 +221,30 @@ func (s *ProjectsServiceOp) Delete(ctx context.Context, projectID string) (*atla
 	}
 
 	basePath := fmt.Sprintf("%s/%s", projectBasePath, projectID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, basePath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// RemoveUser removes a user from a project.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/remove-one-user-from-one-group/
+func (s *ProjectsServiceOp) RemoveUser(ctx context.Context, projectID, userID string) (*atlas.Response, error) {
+	if projectID == "" {
+		return nil, atlas.NewArgError("projectID", "must be set")
+	}
+
+	if userID == "" {
+		return nil, atlas.NewArgError("userID", "must be set")
+	}
+
+	basePath := fmt.Sprintf("%s/%s", projectUsersBasePath, userID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, basePath, nil)
 	if err != nil {

--- a/opsmngr/projects_test.go
+++ b/opsmngr/projects_test.go
@@ -219,26 +219,26 @@ func TestProjects_ListUsers(t *testing.T) {
 			FirstName:    "John",
 			ID:           "59db8d1d87d9d6420df0613a",
 			LastName:     "Smith",
-			Links: []*mongodbatlas.Link{},
-			Roles:        []*UserRole{
+			Links:        []*mongodbatlas.Link{},
+			Roles: []*UserRole{
 				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
 				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
 				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
 			},
-			Username:     "someone@example.com",
+			Username: "someone@example.com",
 		},
 		{
 			EmailAddress: "someone_else@example.com",
 			FirstName:    "Jill",
 			ID:           "59db8d1d87d9d6420df0613a",
 			LastName:     "Smith",
-			Links: []*mongodbatlas.Link{},
-			Roles:        []*UserRole{
+			Links:        []*mongodbatlas.Link{},
+			Roles: []*UserRole{
 				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
 				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
 				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
 			},
-			Username:     "someone@example.com",
+			Username: "someone@example.com",
 		},
 	}
 
@@ -246,7 +246,6 @@ func TestProjects_ListUsers(t *testing.T) {
 		t.Error(diff)
 	}
 }
-
 
 func TestProject_GetOneProject(t *testing.T) {
 	client, mux, teardown := setup()
@@ -478,6 +477,9 @@ func TestProject_Delete(t *testing.T) {
 func TestProject_RemoveUser(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
+
+	var str = fmt.Sprintf("/groups/%s/users/%s", groupID, userID)
+	fmt.Println(str)
 
 	mux.HandleFunc(fmt.Sprintf("/groups/%s/users/%s", groupID, userID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/opsmngr/unauth_users.go
+++ b/opsmngr/unauth_users.go
@@ -68,25 +68,6 @@ type WhitelistOpts struct {
 	Whitelist []string `url:"whitelist"`
 }
 
-// User wrapper for a user response, augmented with a few extra fields
-type User struct {
-	Username     string        `json:"username"`
-	Password     string        `json:"password,omitempty"`
-	FirstName    string        `json:"firstName,omitempty"`
-	LastName     string        `json:"lastName,omitempty"`
-	EmailAddress string        `json:"emailAddress,omitempty"`
-	ID           string        `json:"id,omitempty"`
-	Links        []*atlas.Link `json:"links,omitempty"`
-	Roles        []*UserRole   `json:"roles,omitempty"`
-}
-
-// UserRole denotes a single user role
-type UserRole struct {
-	RoleName string `json:"roleName"`
-	GroupID  string `json:"groupId,omitempty"`
-	OrgID    string `json:"orgId,omitempty"`
-}
-
 // CreateUserResponse API response for the CreateFirstUser() call
 type CreateUserResponse struct {
 	APIKey             string       `json:"apiKey,omitempty"`

--- a/opsmngr/users.go
+++ b/opsmngr/users.go
@@ -1,4 +1,4 @@
-// Copyright 2019 MongoDB Inc
+// Copyright 2020 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opsmngr/users.go
+++ b/opsmngr/users.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	usersBasePath = "users"
-	projectUsersBasePath = "groups/%s/users"
+	usersBasePath    = "users"
 	orgUsersBasePath = "orgs/%s/users"
 )
 
@@ -65,7 +64,7 @@ type UserRole struct {
 // UsersResponse represents a array of users
 type UsersResponse struct {
 	Links      []*atlas.Link `json:"links"`
-	Results    []*User    `json:"results"`
+	Results    []*User       `json:"results"`
 	TotalCount int           `json:"totalCount"`
 }
 

--- a/opsmngr/users.go
+++ b/opsmngr/users.go
@@ -1,0 +1,188 @@
+// Copyright 2019 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opsmngr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	atlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	usersBasePath = "groups/%s/users"
+)
+
+// UsersService provides access to the user related functions in the Ops Manager API.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/
+type UsersService interface {
+	List(context.Context, string, *atlas.ListOptions) ([]*User, *atlas.Response, error)
+	Get(context.Context, string, string) (*User, *atlas.Response, error)
+	GetByName(context.Context, string) (*User, *atlas.Response, error)
+	Create(context.Context, *User) (*User, *atlas.Response, error)
+	Delete(context.Context, string) (*atlas.Response, error)
+}
+
+// UsersServiceOp provides an implementation of the UsersService interface
+type UsersServiceOp service
+
+var _ UsersService = &UsersServiceOp{}
+
+// User wrapper for a user response, augmented with a few extra fields
+type User struct {
+	Username     string        `json:"username"`
+	Password     string        `json:"password,omitempty"`
+	FirstName    string        `json:"firstName,omitempty"`
+	LastName     string        `json:"lastName,omitempty"`
+	EmailAddress string        `json:"emailAddress,omitempty"`
+	ID           string        `json:"id,omitempty"`
+	Links        []*atlas.Link `json:"links,omitempty"`
+	Roles        []*UserRole   `json:"roles,omitempty"`
+}
+
+// UserRole denotes a single user role
+type UserRole struct {
+	RoleName string `json:"roleName"`
+	GroupID  string `json:"groupId,omitempty"`
+	OrgID    string `json:"orgId,omitempty"`
+}
+
+// UsersResponse represents a array of users
+type UsersResponse struct {
+	Links      []*atlas.Link `json:"links"`
+	Results    []*User    `json:"results"`
+	TotalCount int           `json:"totalCount"`
+}
+
+// List gets all users in a project.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/get-all-users-in-one-group/
+func (s *UsersServiceOp) List(ctx context.Context, projectID string, opts *atlas.ListOptions) ([]*User, *atlas.Response, error) {
+	path := fmt.Sprintf(usersBasePath, projectID)
+
+	path, err := setQueryParams(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(UsersResponse)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Results, resp, nil
+}
+
+// Get gets a single user.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/user-get-by-id/
+func (s *UsersServiceOp) Get(ctx context.Context, projectID, userID string) (*User, *atlas.Response, error) {
+	if userID == "" {
+		return nil, nil, atlas.NewArgError("userID", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s/%s", usersBasePath, projectID, userID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(User)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// GetByName gets a single project by its name.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/get-one-group-by-name/
+func (s *UsersServiceOp) GetByName(ctx context.Context, groupName string) (*User, *atlas.Response, error) {
+	if groupName == "" {
+		return nil, nil, atlas.NewArgError("groupName", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/byName/%s", projectBasePath, groupName)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(User)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Create creates an IAM user.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/create-one-group/
+func (s *UsersServiceOp) Create(ctx context.Context, createRequest *User) (*User, *atlas.Response, error) {
+	if createRequest == nil {
+		return nil, nil, atlas.NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, projectBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(User)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Delete deletes a project.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/delete-one-group/
+func (s *UsersServiceOp) Delete(ctx context.Context, projectID string) (*atlas.Response, error) {
+	if projectID == "" {
+		return nil, atlas.NewArgError("projectID", "must be set")
+	}
+
+	basePath := fmt.Sprintf("%s/%s", projectBasePath, projectID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, basePath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/opsmngr/users.go
+++ b/opsmngr/users.go
@@ -36,9 +36,9 @@ type UsersService interface {
 	ListOrgUsers(context.Context, string, *atlas.ListOptions) ([]*User, *atlas.Response, error)
 	Get(context.Context, string) (*User, *atlas.Response, error)
 	GetByName(context.Context, string) (*User, *atlas.Response, error)
-	Invite(context.Context, *User) (*User, *atlas.Response, error)
+	Create(context.Context, *User) (*User, *atlas.Response, error)
 	Delete(context.Context, string) (*atlas.Response, error)
-	DeleteFromProject(context.Context, string, string) (*atlas.Response, error)
+	RemoveFromProject(context.Context, string, string) (*atlas.Response, error)
 }
 
 // UsersServiceOp provides an implementation of the UsersService interface
@@ -101,7 +101,7 @@ func (s *UsersServiceOp) ListProjectUsers(ctx context.Context, projectID string,
 	return root.Results, resp, nil
 }
 
-// ListOrgUsers gets all users in an organisation.
+// ListOrgUsers gets all users in an organization.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/get-all-users-in-one-group/
 func (s *UsersServiceOp) ListOrgUsers(ctx context.Context, orgID string, opts *atlas.ListOptions) ([]*User, *atlas.Response, error) {
@@ -130,7 +130,7 @@ func (s *UsersServiceOp) ListOrgUsers(ctx context.Context, orgID string, opts *a
 	return root.Results, resp, nil
 }
 
-// Get gets a single user.
+// Get gets a single user by ID.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/user-get-by-id/
 func (s *UsersServiceOp) Get(ctx context.Context, userID string) (*User, *atlas.Response, error) {
@@ -154,7 +154,7 @@ func (s *UsersServiceOp) Get(ctx context.Context, userID string) (*User, *atlas.
 	return root, resp, err
 }
 
-// GetByName gets a single user.
+// GetByName gets a single user by name.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/user-get-by-name/
 func (s *UsersServiceOp) GetByName(ctx context.Context, username string) (*User, *atlas.Response, error) {
@@ -178,10 +178,10 @@ func (s *UsersServiceOp) GetByName(ctx context.Context, username string) (*User,
 	return root, resp, err
 }
 
-// Invite creates an IAM user.
+// Create creates a new IAM user.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/user-create/
-func (s *UsersServiceOp) Invite(ctx context.Context, createRequest *User) (*User, *atlas.Response, error) {
+func (s *UsersServiceOp) Create(ctx context.Context, createRequest *User) (*User, *atlas.Response, error) {
 	if createRequest == nil {
 		return nil, nil, atlas.NewArgError("createRequest", "cannot be nil")
 	}
@@ -220,10 +220,10 @@ func (s *UsersServiceOp) Delete(ctx context.Context, userID string) (*atlas.Resp
 	return resp, err
 }
 
-// DeleteFromProject removes a user from a project.
+// RemoveFromProject removes a user from a project.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/groups/remove-one-user-from-one-group/
-func (s *UsersServiceOp) DeleteFromProject(ctx context.Context, projectID, userID string) (*atlas.Response, error) {
+func (s *UsersServiceOp) RemoveFromProject(ctx context.Context, projectID, userID string) (*atlas.Response, error) {
 	if projectID == "" {
 		return nil, atlas.NewArgError("projectID", "must be set")
 	}

--- a/opsmngr/users_test.go
+++ b/opsmngr/users_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 MongoDB Inc
+// Copyright 2020 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opsmngr/users_test.go
+++ b/opsmngr/users_test.go
@@ -1,0 +1,203 @@
+// Copyright 2019 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opsmngr
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+	"go.mongodb.org/atlas/mongodbatlas"
+)
+
+const userID = "56a10a80e4b0fd3b9a9bb0c2"
+const userName = "someone@example.com"
+
+func TestUsers_Get(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/users/%s", userID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+		 	"emailAddress": "someone@example.com",
+		   "firstName": "John",
+		   "id": "59db8d1d87d9d6420df0613a",
+		   "lastName": "Smith",
+		   "links": [],
+		   "roles": [{
+			 "groupId": "59ea02e087d9d636b587a967",
+			 "roleName": "GROUP_OWNER"
+		   }, {
+			 "groupId": "59db8d1d87d9d6420df70902",
+			 "roleName": "GROUP_OWNER"
+		   }, {
+			 "orgId": "59db8d1d87d9d6420df0613f",
+			 "roleName": "ORG_OWNER"
+		   }],
+		   "username": "someone@example.com"
+		}`)
+	})
+
+	projects, _, err := client.Users.Get(ctx, userID)
+	if err != nil {
+		t.Fatalf("Users.Get returned error: %v", err)
+	}
+
+	expected := &User{
+			EmailAddress: "someone@example.com",
+			FirstName:    "John",
+			ID:           "59db8d1d87d9d6420df0613a",
+			LastName:     "Smith",
+			Links: []*mongodbatlas.Link{},
+			Roles:        []*UserRole{
+				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+			},
+			Username:     "someone@example.com",
+	}
+
+	if diff := deep.Equal(projects, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestUsers_GetByName(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/users/byName/%s", userName), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+		 	"emailAddress": "someone@example.com",
+		   "firstName": "John",
+		   "id": "59db8d1d87d9d6420df0613a",
+		   "lastName": "Smith",
+		   "links": [],
+		   "roles": [{
+			 "groupId": "59ea02e087d9d636b587a967",
+			 "roleName": "GROUP_OWNER"
+		   }, {
+			 "groupId": "59db8d1d87d9d6420df70902",
+			 "roleName": "GROUP_OWNER"
+		   }, {
+			 "orgId": "59db8d1d87d9d6420df0613f",
+			 "roleName": "ORG_OWNER"
+		   }],
+		   "username": "someone@example.com"
+		}`)
+	})
+
+	projects, _, err := client.Users.GetByName(ctx, userName)
+	if err != nil {
+		t.Fatalf("Users.GetByName returned error: %v", err)
+	}
+
+	expected := &User{
+		EmailAddress: "someone@example.com",
+		FirstName:    "John",
+		ID:           "59db8d1d87d9d6420df0613a",
+		LastName:     "Smith",
+		Links: []*mongodbatlas.Link{},
+		Roles:        []*UserRole{
+			{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+			{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+			{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+		},
+		Username:     "someone@example.com",
+	}
+
+	if diff := deep.Equal(projects, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestUsers_Create(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		_, _ = fmt.Fprint(w, `{
+		 	"emailAddress": "someone@example.com",
+		   "firstName": "John",
+		   "id": "59db8d1d87d9d6420df0613a",
+		   "lastName": "Smith",
+		   "links": [],
+		   "roles": [{
+			 "groupId": "59ea02e087d9d636b587a967",
+			 "roleName": "GROUP_OWNER"
+		   }, {
+			 "groupId": "59db8d1d87d9d6420df70902",
+			 "roleName": "GROUP_OWNER"
+		   }, {
+			 "orgId": "59db8d1d87d9d6420df0613f",
+			 "roleName": "ORG_OWNER"
+		   }],
+		   "username": "someone@example.com"
+		}`)
+	})
+
+	createRequest := &User{
+		Username:     "someone@example.com",
+		Password:     "some_pass",
+		FirstName:    "John",
+		LastName:     "Smith",
+		EmailAddress: "john.smith@mongodb.com",
+		Links:        nil,
+		Roles:        []*UserRole{
+			{RoleName: "ORG_OWNER", OrgID: "59db8d1d87d9d6420df0613f"},
+		},
+	}
+
+	userResponse, _, err := client.Users.Create(ctx, createRequest)
+	if err != nil {
+		t.Fatalf("Users.Create returned error: %v", err)
+	}
+
+	expected := &User{
+		EmailAddress: "someone@example.com",
+		FirstName:    "John",
+		ID:           "59db8d1d87d9d6420df0613a",
+		LastName:     "Smith",
+		Links: []*mongodbatlas.Link{},
+		Roles:        []*UserRole{
+			{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+			{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+			{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+		},
+		Username:     "someone@example.com",
+	}
+
+	if diff := deep.Equal(userResponse, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestUsers_Delete(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/users/%s", userID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.Users.Delete(ctx, userID)
+	if err != nil {
+		t.Fatalf("Users.Delete returned error: %v", err)
+	}
+}

--- a/opsmngr/users_test.go
+++ b/opsmngr/users_test.go
@@ -58,17 +58,17 @@ func TestUsers_Get(t *testing.T) {
 	}
 
 	expected := &User{
-			EmailAddress: "someone@example.com",
-			FirstName:    "John",
-			ID:           "59db8d1d87d9d6420df0613a",
-			LastName:     "Smith",
-			Links: []*mongodbatlas.Link{},
-			Roles:        []*UserRole{
-				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
-				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
-				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
-			},
-			Username:     "someone@example.com",
+		EmailAddress: "someone@example.com",
+		FirstName:    "John",
+		ID:           "59db8d1d87d9d6420df0613a",
+		LastName:     "Smith",
+		Links:        []*mongodbatlas.Link{},
+		Roles: []*UserRole{
+			{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+			{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+			{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+		},
+		Username: "someone@example.com",
 	}
 
 	if diff := deep.Equal(projects, expected); diff != nil {
@@ -112,13 +112,13 @@ func TestUsers_GetByName(t *testing.T) {
 		FirstName:    "John",
 		ID:           "59db8d1d87d9d6420df0613a",
 		LastName:     "Smith",
-		Links: []*mongodbatlas.Link{},
-		Roles:        []*UserRole{
+		Links:        []*mongodbatlas.Link{},
+		Roles: []*UserRole{
 			{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
 			{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
 			{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
 		},
-		Username:     "someone@example.com",
+		Username: "someone@example.com",
 	}
 
 	if diff := deep.Equal(projects, expected); diff != nil {
@@ -159,7 +159,7 @@ func TestUsers_Create(t *testing.T) {
 		LastName:     "Smith",
 		EmailAddress: "john.smith@mongodb.com",
 		Links:        nil,
-		Roles:        []*UserRole{
+		Roles: []*UserRole{
 			{RoleName: "ORG_OWNER", OrgID: "59db8d1d87d9d6420df0613f"},
 		},
 	}
@@ -174,13 +174,13 @@ func TestUsers_Create(t *testing.T) {
 		FirstName:    "John",
 		ID:           "59db8d1d87d9d6420df0613a",
 		LastName:     "Smith",
-		Links: []*mongodbatlas.Link{},
-		Roles:        []*UserRole{
+		Links:        []*mongodbatlas.Link{},
+		Roles: []*UserRole{
 			{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
 			{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
 			{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
 		},
-		Username:     "someone@example.com",
+		Username: "someone@example.com",
 	}
 
 	if diff := deep.Equal(userResponse, expected); diff != nil {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

This adds methods for IAM users in OM

_Jira ticket:_ CLOUDP-70161

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

Closes #[issue number]

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code

## Further comments

