### PR TITLE
[fix] Change the return of user lists to match Atlas

### DIFF
--- a/opsmngr/organizations.go
+++ b/opsmngr/organizations.go
@@ -31,7 +31,7 @@ const (
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/
 type OrganizationsService interface {
 	List(context.Context, *atlas.ListOptions) (*atlas.Organizations, *atlas.Response, error)
-	ListUsers(context.Context, string, *atlas.ListOptions) ([]*User, *atlas.Response, error)
+	ListUsers(context.Context, string, *atlas.ListOptions) (*UsersResponse, *atlas.Response, error)
 	Get(context.Context, string) (*atlas.Organization, *atlas.Response, error)
 	Projects(context.Context, string, *atlas.ListOptions) (*Projects, *atlas.Response, error)
 	Create(context.Context, *atlas.Organization) (*atlas.Organization, *atlas.Response, error)
@@ -72,7 +72,7 @@ func (s *OrganizationsServiceOp) List(ctx context.Context, opts *atlas.ListOptio
 // ListUsers gets all users in an organization.
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/organization-get-all-users/
-func (s *OrganizationsServiceOp) ListUsers(ctx context.Context, orgID string, opts *atlas.ListOptions) ([]*User, *atlas.Response, error) {
+func (s *OrganizationsServiceOp) ListUsers(ctx context.Context, orgID string, opts *atlas.ListOptions) (*UsersResponse, *atlas.Response, error) {
 	path := fmt.Sprintf(orgUsersBasePath, orgID)
 
 	path, err := setQueryParams(path, opts)
@@ -95,7 +95,7 @@ func (s *OrganizationsServiceOp) ListUsers(ctx context.Context, orgID string, op
 		resp.Links = l
 	}
 
-	return root.Results, resp, nil
+	return root, resp, nil
 }
 
 // Get gets a single organization.

--- a/opsmngr/organizations_test.go
+++ b/opsmngr/organizations_test.go
@@ -142,7 +142,8 @@ func TestOrganizations_ListUsers(t *testing.T) {
 				 "roleName": "ORG_OWNER"
 			   }],
 			   "username": "someone@example.com"
-			}]
+			}],
+			"totalCount": 2
 		},`)
 	})
 
@@ -151,33 +152,42 @@ func TestOrganizations_ListUsers(t *testing.T) {
 		t.Fatalf("Organizations.ListUsers returned error: %v", err)
 	}
 
-	expected := []*User{
-		{
-			EmailAddress: "someone@example.com",
-			FirstName:    "John",
-			ID:           "59db8d1d87d9d6420df0613a",
-			LastName:     "Smith",
-			Links:        []*mongodbatlas.Link{},
-			Roles: []*UserRole{
-				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
-				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
-				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+	expected := &UsersResponse{
+		Links: []*mongodbatlas.Link{
+			{
+				Rel:  "self",
+				Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/users",
 			},
-			Username: "someone@example.com",
 		},
-		{
-			EmailAddress: "someone_else@example.com",
-			FirstName:    "Jill",
-			ID:           "59db8d1d87d9d6420df0613a",
-			LastName:     "Smith",
-			Links:        []*mongodbatlas.Link{},
-			Roles: []*UserRole{
-				{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
-				{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
-				{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+		Results: []*User{
+			{
+				EmailAddress: "someone@example.com",
+				FirstName:    "John",
+				ID:           "59db8d1d87d9d6420df0613a",
+				LastName:     "Smith",
+				Links:        []*mongodbatlas.Link{},
+				Roles: []*UserRole{
+					{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+					{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+					{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+				},
+				Username: "someone@example.com",
 			},
-			Username: "someone@example.com",
+			{
+				EmailAddress: "someone_else@example.com",
+				FirstName:    "Jill",
+				ID:           "59db8d1d87d9d6420df0613a",
+				LastName:     "Smith",
+				Links:        []*mongodbatlas.Link{},
+				Roles: []*UserRole{
+					{GroupID: "59ea02e087d9d636b587a967", RoleName: "GROUP_OWNER"},
+					{GroupID: "59db8d1d87d9d6420df70902", RoleName: "GROUP_OWNER"},
+					{OrgID: "59db8d1d87d9d6420df0613f", RoleName: "ORG_OWNER"},
+				},
+				Username: "someone@example.com",
+			},
 		},
+		TotalCount: 2,
 	}
 
 	if diff := deep.Equal(orgs, expected); diff != nil {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

Match the return to Atlas


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

