### PR TITLE
CLOUDP-72553: add maintenance windows api to ops manager go client

### DIFF
--- a/opsmngr/maintenance.go
+++ b/opsmngr/maintenance.go
@@ -1,0 +1,180 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opsmngr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	atlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	maintenanceWindowsBasePath = "groups/%s/maintenanceWindows"
+)
+
+// MaintenanceWindowsService is an interface for interfacing with the Maintenance Windows
+// endpoints of the MongoDB Ops Manager API.
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows/
+type MaintenanceWindowsService interface {
+	Get(context.Context, string, string) (*MaintenanceWindow, *atlas.Response, error)
+	List(context.Context, string) (*MaintenanceWindows, *atlas.Response, error)
+	Create(context.Context, string, *MaintenanceWindow) (*MaintenanceWindow, *atlas.Response, error)
+	Update(context.Context, string, string, *MaintenanceWindow) (*MaintenanceWindow, *atlas.Response, error)
+	Delete(context.Context, string, string) (*atlas.Response, error)
+}
+
+// MaintenanceWindow represents MongoDB Maintenance Windows
+type MaintenanceWindow struct {
+	ID             string   `json:"id"`
+	GroupId        string   `json:"groupId"`
+	Created        string   `json:"created"`
+	StartDate      string   `json:"startDate,omitempty"`
+	EndDate        string   `json:"endDate,omitempty"`
+	Updated        string   `json:"updated,omitempty"`
+	AlertTypeNames []string `json:"alertTypeNames,omitempty"`
+	Description    string   `json:"description,omitempty"`
+}
+
+// MaintenanceWindows is the response from the EventsService.List.
+type MaintenanceWindows struct {
+	Links      []*atlas.Link        `json:"links,omitempty"`
+	Results    []*MaintenanceWindow `json:"results,omitempty"`
+	TotalCount int                  `json:"totalCount,omitempty"`
+}
+
+// MaintenanceWindowsServiceOp handles communication with the MaintenanceWindows related methods
+// of the OpsManager Atlas API
+type MaintenanceWindowsServiceOp service
+
+var _ MaintenanceWindowsService = &MaintenanceWindowsServiceOp{}
+
+// List gets all maintenance windows.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows-get-all/
+func (s *MaintenanceWindowsServiceOp) List(ctx context.Context, groupID string) (*MaintenanceWindows, *atlas.Response, error) {
+	if groupID == "" {
+		return nil, nil, atlas.NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(maintenanceWindowsBasePath, groupID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(MaintenanceWindows)
+	resp, err := s.Client.Do(ctx, req, root)
+
+	return root, resp, err
+}
+
+// Get gets a maintenance window.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows-get-one/
+func (s *MaintenanceWindowsServiceOp) Get(ctx context.Context, groupID, maintenanceWindowID string) (*MaintenanceWindow, *atlas.Response, error) {
+	if groupID == "" {
+		return nil, nil, atlas.NewArgError("groupID", "must be set")
+	}
+
+	if maintenanceWindowID == "" {
+		return nil, nil, atlas.NewArgError("maintenanceWindowID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(maintenanceWindowsBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, maintenanceWindowID)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(MaintenanceWindow)
+	resp, err := s.Client.Do(ctx, req, root)
+
+	return root, resp, err
+}
+
+// Create creates one maintenance window.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows-create-one/
+func (s *MaintenanceWindowsServiceOp) Create(ctx context.Context, groupID string, maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *atlas.Response, error) {
+	if groupID == "" {
+		return nil, nil, atlas.NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(maintenanceWindowsBasePath, groupID)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, maintenanceWindow)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(MaintenanceWindow)
+	resp, err := s.Client.Do(ctx, req, root)
+
+	return root, resp, err
+}
+
+// Update updates one maintenance window with an end date in the future.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows-update-one/
+func (s *MaintenanceWindowsServiceOp) Update(ctx context.Context, groupID, maintenanceWindowID string, maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *atlas.Response, error) {
+	if groupID == "" {
+		return nil, nil, atlas.NewArgError("groupID", "must be set")
+	}
+
+	if maintenanceWindowID == "" {
+		return nil, nil, atlas.NewArgError("maintenanceWindowID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(maintenanceWindowsBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, maintenanceWindowID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, maintenanceWindow)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(MaintenanceWindow)
+	resp, err := s.Client.Do(ctx, req, root)
+
+	return root, resp, err
+}
+
+// Delete removes one maintenance window with an end date in the future.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows-delete-one/
+func (s *MaintenanceWindowsServiceOp) Delete(ctx context.Context, groupID, maintenanceWindowID string) (*atlas.Response, error) {
+	if groupID == "" {
+		return nil, atlas.NewArgError("groupID", "must be set")
+	}
+
+	if maintenanceWindowID == "" {
+		return nil, atlas.NewArgError("maintenanceWindowID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(maintenanceWindowsBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, maintenanceWindowID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/opsmngr/maintenance.go
+++ b/opsmngr/maintenance.go
@@ -49,7 +49,7 @@ type MaintenanceWindow struct {
 	Description    string   `json:"description,omitempty"`
 }
 
-// MaintenanceWindows is the response from the EventsService.List.
+// MaintenanceWindows is the response from the MaintenanceWindowsService.List.
 type MaintenanceWindows struct {
 	Links      []*atlas.Link        `json:"links,omitempty"`
 	Results    []*MaintenanceWindow `json:"results,omitempty"`

--- a/opsmngr/maintenance.go
+++ b/opsmngr/maintenance.go
@@ -28,6 +28,7 @@ const (
 
 // MaintenanceWindowsService is an interface for interfacing with the Maintenance Windows
 // endpoints of the MongoDB Ops Manager API.
+//
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/maintenance-windows/
 type MaintenanceWindowsService interface {
 	Get(context.Context, string, string) (*MaintenanceWindow, *atlas.Response, error)

--- a/opsmngr/maintenance.go
+++ b/opsmngr/maintenance.go
@@ -40,7 +40,7 @@ type MaintenanceWindowsService interface {
 // MaintenanceWindow represents MongoDB Maintenance Windows
 type MaintenanceWindow struct {
 	ID             string   `json:"id"`
-	GroupId        string   `json:"groupId"`
+	GroupID        string   `json:"groupId"`
 	Created        string   `json:"created"`
 	StartDate      string   `json:"startDate,omitempty"`
 	EndDate        string   `json:"endDate,omitempty"`

--- a/opsmngr/maintenance_test.go
+++ b/opsmngr/maintenance_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/go-test/deep"
 )
 
+const ID = "5628faffd4c606594adaa3b2"
+
 func TestMaintenanceWindows_List(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
@@ -64,7 +66,7 @@ func TestMaintenanceWindows_List(t *testing.T) {
 		Results: []*MaintenanceWindow{
 			{
 				ID:             "5628faffd4c606594adaa3b2",
-				GroupId:        "{PROJECT-ID}",
+				GroupID:        "{PROJECT-ID}",
 				Created:        "2015-10-22T15:04:31Z",
 				StartDate:      "2015-10-23T22:00:00Z",
 				EndDate:        "2015-10-23T23:30:00Z",
@@ -74,7 +76,7 @@ func TestMaintenanceWindows_List(t *testing.T) {
 			},
 			{
 				ID:             "56290359d4c606594adaafe8",
-				GroupId:        "{PROJECT-ID}",
+				GroupID:        "{PROJECT-ID}",
 				Created:        "2015-10-22T15:40:09Z",
 				StartDate:      "2015-10-23T22:00:00Z",
 				EndDate:        "2015-10-23T23:30:00Z",
@@ -93,7 +95,6 @@ func TestMaintenanceWindows_List(t *testing.T) {
 func TestMaintenanceWindows_Get(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
-	ID := "5628faffd4c606594adaa3b2"
 	path := fmt.Sprintf("/groups/%s/maintenanceWindows/%s", groupID, ID)
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +118,7 @@ func TestMaintenanceWindows_Get(t *testing.T) {
 
 	expected := &MaintenanceWindow{
 		ID:             "5628faffd4c606594adaa3b2",
-		GroupId:        "{PROJECT-ID}",
+		GroupID:        "{PROJECT-ID}",
 		Created:        "2015-10-22T15:04:31Z",
 		StartDate:      "2015-10-23T22:00:00Z",
 		EndDate:        "2015-10-23T23:30:00Z",
@@ -163,7 +164,7 @@ func TestMaintenanceWindows_Create(t *testing.T) {
 
 	expected := &MaintenanceWindow{
 		ID:             "5628faffd4c606594adaa3b2",
-		GroupId:        "{PROJECT-ID}",
+		GroupID:        "{PROJECT-ID}",
 		Created:        "2015-10-22T15:04:31Z",
 		StartDate:      "2015-10-23T22:00:00Z",
 		EndDate:        "2015-10-23T23:30:00Z",
@@ -180,8 +181,6 @@ func TestMaintenanceWindows_Create(t *testing.T) {
 func TestMaintenanceWindows_Update(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
-
-	ID := "5628faffd4c606594adaa3b2"
 	path := fmt.Sprintf("/groups/%s/maintenanceWindows/%s", groupID, ID)
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +210,7 @@ func TestMaintenanceWindows_Update(t *testing.T) {
 
 	expected := &MaintenanceWindow{
 		ID:             "5628faffd4c606594adaa3b2",
-		GroupId:        "{PROJECT-ID}",
+		GroupID:        "{PROJECT-ID}",
 		Created:        "2015-10-22T15:04:31Z",
 		StartDate:      "2015-10-23T22:00:00Z",
 		EndDate:        "2015-10-23T23:30:00Z",
@@ -228,8 +227,6 @@ func TestMaintenanceWindows_Update(t *testing.T) {
 func TestMaintenanceWindows_Delete(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
-
-	ID := "5628faffd4c606594adaa3b2"
 
 	path := fmt.Sprintf("/groups/%s/maintenanceWindows/%s", groupID, ID)
 

--- a/opsmngr/maintenance_test.go
+++ b/opsmngr/maintenance_test.go
@@ -1,0 +1,244 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opsmngr
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestMaintenanceWindows_List(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	path := fmt.Sprintf("/groups/%s/maintenanceWindows", groupID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+			  "results": [
+				{
+					"alertTypeNames" : [ "BACKUP" ],
+					"created" : "2015-10-22T15:04:31Z",
+					"description" : "new description",
+					"endDate" : "2015-10-23T23:30:00Z",
+					"groupId" : "{PROJECT-ID}",
+					"id" : "5628faffd4c606594adaa3b2",
+					"startDate" : "2015-10-23T22:00:00Z",
+					"updated" : "2015-10-22T15:04:31Z"
+				  }, {
+					"alertTypeNames" : [ "AGENT", "BACKUP" ],
+					"created" : "2015-10-22T15:40:09Z",
+					"endDate" : "2015-10-23T23:30:00Z",
+					"groupId" : "{PROJECT-ID}",
+					"id" : "56290359d4c606594adaafe8",
+					"startDate" : "2015-10-23T22:00:00Z",
+					"updated" : "2015-10-22T15:40:09Z"
+				}
+			  ],
+			  "totalCount": 2
+			}`)
+	})
+
+	maintenanceWindows, _, err := client.MaintenanceWindows.List(ctx, groupID)
+	if err != nil {
+		t.Fatalf("MaintenanceWindows.List returned error: %v", err)
+	}
+
+	expected := &MaintenanceWindows{
+		Results: []*MaintenanceWindow{
+			{
+				ID:             "5628faffd4c606594adaa3b2",
+				GroupId:        "{PROJECT-ID}",
+				Created:        "2015-10-22T15:04:31Z",
+				StartDate:      "2015-10-23T22:00:00Z",
+				EndDate:        "2015-10-23T23:30:00Z",
+				Updated:        "2015-10-22T15:04:31Z",
+				AlertTypeNames: []string{"BACKUP"},
+				Description:    "new description",
+			},
+			{
+				ID:             "56290359d4c606594adaafe8",
+				GroupId:        "{PROJECT-ID}",
+				Created:        "2015-10-22T15:40:09Z",
+				StartDate:      "2015-10-23T22:00:00Z",
+				EndDate:        "2015-10-23T23:30:00Z",
+				Updated:        "2015-10-22T15:40:09Z",
+				AlertTypeNames: []string{"AGENT", "BACKUP"},
+			},
+		},
+		TotalCount: 2,
+	}
+
+	if diff := deep.Equal(maintenanceWindows, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestMaintenanceWindows_Get(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+	ID := "5628faffd4c606594adaa3b2"
+	path := fmt.Sprintf("/groups/%s/maintenanceWindows/%s", groupID, ID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+					"alertTypeNames" : [ "BACKUP" ],
+					"created" : "2015-10-22T15:04:31Z",
+					"description" : "new description",
+					"endDate" : "2015-10-23T23:30:00Z",
+					"groupId" : "{PROJECT-ID}",
+					"id" : "5628faffd4c606594adaa3b2",
+					"startDate" : "2015-10-23T22:00:00Z",
+					"updated" : "2015-10-22T15:04:31Z"
+			}`)
+	})
+
+	maintenanceWindow, _, err := client.MaintenanceWindows.Get(ctx, groupID, ID)
+	if err != nil {
+		t.Fatalf("MaintenanceWindows.Get returned error: %v", err)
+	}
+
+	expected := &MaintenanceWindow{
+		ID:             "5628faffd4c606594adaa3b2",
+		GroupId:        "{PROJECT-ID}",
+		Created:        "2015-10-22T15:04:31Z",
+		StartDate:      "2015-10-23T22:00:00Z",
+		EndDate:        "2015-10-23T23:30:00Z",
+		Updated:        "2015-10-22T15:04:31Z",
+		AlertTypeNames: []string{"BACKUP"},
+		Description:    "new description",
+	}
+
+	if diff := deep.Equal(maintenanceWindow, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestMaintenanceWindows_Create(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+	path := fmt.Sprintf("/groups/%s/maintenanceWindows", groupID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		_, _ = fmt.Fprint(w, `{
+					"alertTypeNames" : [ "BACKUP" ],
+					"created" : "2015-10-22T15:04:31Z",
+					"description" : "new description",
+					"endDate" : "2015-10-23T23:30:00Z",
+					"groupId" : "{PROJECT-ID}",
+					"id" : "5628faffd4c606594adaa3b2",
+					"startDate" : "2015-10-23T22:00:00Z",
+					"updated" : "2015-10-22T15:04:31Z"
+			}`)
+	})
+
+	maintenance := &MaintenanceWindow{
+		EndDate:        "2015-10-23T23:30:00Z",
+		Updated:        "2015-10-22T15:04:31Z",
+		AlertTypeNames: []string{"BACKUP"},
+		Description:    "new description",
+	}
+	maintenanceWindow, _, err := client.MaintenanceWindows.Create(ctx, groupID, maintenance)
+	if err != nil {
+		t.Fatalf("MaintenanceWindows.Create returned error: %v", err)
+	}
+
+	expected := &MaintenanceWindow{
+		ID:             "5628faffd4c606594adaa3b2",
+		GroupId:        "{PROJECT-ID}",
+		Created:        "2015-10-22T15:04:31Z",
+		StartDate:      "2015-10-23T22:00:00Z",
+		EndDate:        "2015-10-23T23:30:00Z",
+		Updated:        "2015-10-22T15:04:31Z",
+		AlertTypeNames: []string{"BACKUP"},
+		Description:    "new description",
+	}
+
+	if diff := deep.Equal(maintenanceWindow, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestMaintenanceWindows_Update(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	ID := "5628faffd4c606594adaa3b2"
+	path := fmt.Sprintf("/groups/%s/maintenanceWindows/%s", groupID, ID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		_, _ = fmt.Fprint(w, `{
+					"alertTypeNames" : [ "BACKUP" ],
+					"created" : "2015-10-22T15:04:31Z",
+					"description" : "new description",
+					"endDate" : "2015-10-23T23:30:00Z",
+					"groupId" : "{PROJECT-ID}",
+					"id" : "5628faffd4c606594adaa3b2",
+					"startDate" : "2015-10-23T22:00:00Z",
+					"updated" : "2015-10-22T15:04:31Z"
+			}`)
+	})
+
+	maintenance := &MaintenanceWindow{
+		EndDate:        "2015-10-23T23:30:00Z",
+		Updated:        "2015-10-22T15:04:31Z",
+		AlertTypeNames: []string{"BACKUP"},
+		Description:    "new description",
+	}
+	maintenanceWindow, _, err := client.MaintenanceWindows.Update(ctx, groupID, ID, maintenance)
+	if err != nil {
+		t.Fatalf("MaintenanceWindows.Update returned error: %v", err)
+	}
+
+	expected := &MaintenanceWindow{
+		ID:             "5628faffd4c606594adaa3b2",
+		GroupId:        "{PROJECT-ID}",
+		Created:        "2015-10-22T15:04:31Z",
+		StartDate:      "2015-10-23T22:00:00Z",
+		EndDate:        "2015-10-23T23:30:00Z",
+		Updated:        "2015-10-22T15:04:31Z",
+		AlertTypeNames: []string{"BACKUP"},
+		Description:    "new description",
+	}
+
+	if diff := deep.Equal(maintenanceWindow, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestMaintenanceWindows_Delete(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	ID := "5628faffd4c606594adaa3b2"
+
+	path := fmt.Sprintf("/groups/%s/maintenanceWindows/%s", groupID, ID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.MaintenanceWindows.Delete(ctx, groupID, ID)
+	if err != nil {
+		t.Fatalf("MaintenanceWindows.Delete returned error: %v", err)
+	}
+}

--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -71,6 +71,7 @@ type Client struct {
 	Diagnostics            DiagnosticsService
 	GlobalAPIKeys          GlobalAPIKeysService
 	GlobalAPIKeysWhitelist GlobalAPIKeyWhitelistsService
+	MaintenanceWindows     MaintenanceWindowsService
 
 	onRequestCompleted atlas.RequestCompletionCallback
 }
@@ -121,6 +122,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.WhitelistAPIKeys = &atlas.WhitelistAPIKeysServiceOp{Client: c}
 	c.GlobalAPIKeys = &GlobalAPIKeysServiceOp{Client: c}
 	c.GlobalAPIKeysWhitelist = &GlobalAPIKeyWhitelistsServiceOp{Client: c}
+	c.MaintenanceWindows = &MaintenanceWindowsServiceOp{Client: c}
 
 	return c
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-72553

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
