### PR TITLE
CLOUDP-74339: Update FileSystemStoreConfiguration to include BackupStore in the ops manager go client

### DIFF
--- a/opsmngr/file_system_store_config.go
+++ b/opsmngr/file_system_store_config.go
@@ -47,7 +47,6 @@ type FileSystemStoreConfiguration struct {
 	MMAPV1CompressionSetting string `json:"mmapv1CompressionSetting,omitempty"`
 	StorePath                string `json:"storePath,omitempty"`
 	WTCompressionSetting     string `json:"wtCompressionSetting,omitempty"`
-	AssignmentEnabled        *bool  `json:"assignmentEnabled,omitempty"`
 }
 
 // FileSystemStoreConfigurations represents a paginated collection of FileSystemStoreConfiguration

--- a/opsmngr/file_system_store_config.go
+++ b/opsmngr/file_system_store_config.go
@@ -43,8 +43,7 @@ var _ FileSystemStoreConfigService = &FileSystemStoreConfigServiceOp{}
 
 // FileSystemStoreConfiguration represents a File System Store Configuration in the MongoDB Ops Manager API
 type FileSystemStoreConfiguration struct {
-	AdminBackupConfig
-	LoadFactor               int64  `json:"loadFactor,omitempty"`
+	BackupStore
 	MMAPV1CompressionSetting string `json:"mmapv1CompressionSetting,omitempty"`
 	StorePath                string `json:"storePath,omitempty"`
 	WTCompressionSetting     string `json:"wtCompressionSetting,omitempty"`

--- a/opsmngr/file_system_store_config_test.go
+++ b/opsmngr/file_system_store_config_test.go
@@ -55,15 +55,15 @@ func TestFileSystemStoreConfigServiceOp_List(t *testing.T) {
 			{
 				BackupStore: BackupStore{
 					AdminBackupConfig: AdminBackupConfig{
-						ID:     ID,
-						Labels: []string{"l1", "l2"},
+						ID:                ID,
+						Labels:            []string{"l1", "l2"},
+						AssignmentEnabled: &assignmentEnabled,
 					},
 					LoadFactor: &loadFactor,
 				},
 				MMAPV1CompressionSetting: "NONE",
 				StorePath:                "/data/backup",
 				WTCompressionSetting:     "ZLIB",
-				AssignmentEnabled:        &assignmentEnabled,
 			},
 		},
 		TotalCount: 1,
@@ -101,15 +101,15 @@ func TestFileSystemStoreConfigServiceOp_Get(t *testing.T) {
 	expected := &FileSystemStoreConfiguration{
 		BackupStore: BackupStore{
 			AdminBackupConfig: AdminBackupConfig{
-				ID:     ID,
-				Labels: []string{"l1", "l2"},
+				ID:                ID,
+				Labels:            []string{"l1", "l2"},
+				AssignmentEnabled: &assignmentEnabled,
 			},
 			LoadFactor: &loadFactor,
 		},
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
-		AssignmentEnabled:        &assignmentEnabled,
 	}
 
 	if diff := deep.Equal(config, expected); diff != nil {
@@ -140,15 +140,15 @@ func TestFileSystemStoreConfigServiceOp_Create(t *testing.T) {
 	fileSystem := &FileSystemStoreConfiguration{
 		BackupStore: BackupStore{
 			AdminBackupConfig: AdminBackupConfig{
-				ID:     ID,
-				Labels: []string{"l1", "l2"},
+				ID:                ID,
+				Labels:            []string{"l1", "l2"},
+				AssignmentEnabled: &assignmentEnabled,
 			},
 			LoadFactor: &loadFactor,
 		},
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
-		AssignmentEnabled:        &assignmentEnabled,
 	}
 
 	config, _, err := client.FileSystemStoreConfig.Create(ctx, fileSystem)
@@ -159,15 +159,15 @@ func TestFileSystemStoreConfigServiceOp_Create(t *testing.T) {
 	expected := &FileSystemStoreConfiguration{
 		BackupStore: BackupStore{
 			AdminBackupConfig: AdminBackupConfig{
-				ID:     ID,
-				Labels: []string{"l1", "l2"},
+				ID:                ID,
+				Labels:            []string{"l1", "l2"},
+				AssignmentEnabled: &assignmentEnabled,
 			},
 			LoadFactor: &loadFactor,
 		},
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
-		AssignmentEnabled:        &assignmentEnabled,
 	}
 
 	if diff := deep.Equal(config, expected); diff != nil {
@@ -198,15 +198,15 @@ func TestFileSystemStoreConfigServiceOp_Update(t *testing.T) {
 	fileSystem := &FileSystemStoreConfiguration{
 		BackupStore: BackupStore{
 			AdminBackupConfig: AdminBackupConfig{
-				ID:     ID,
-				Labels: []string{"l1", "l2"},
+				ID:                ID,
+				Labels:            []string{"l1", "l2"},
+				AssignmentEnabled: &assignmentEnabled,
 			},
 			LoadFactor: &loadFactor,
 		},
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
-		AssignmentEnabled:        &assignmentEnabled,
 	}
 
 	config, _, err := client.FileSystemStoreConfig.Update(ctx, ID, fileSystem)
@@ -217,8 +217,9 @@ func TestFileSystemStoreConfigServiceOp_Update(t *testing.T) {
 	expected := &FileSystemStoreConfiguration{
 		BackupStore: BackupStore{
 			AdminBackupConfig: AdminBackupConfig{
-				ID:     ID,
-				Labels: []string{"l1", "l2"},
+				ID:                ID,
+				Labels:            []string{"l1", "l2"},
+				AssignmentEnabled: &assignmentEnabled,
 			},
 			LoadFactor:    &loadFactor,
 			MaxCapacityGB: nil,
@@ -229,7 +230,6 @@ func TestFileSystemStoreConfigServiceOp_Update(t *testing.T) {
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
-		AssignmentEnabled:        &assignmentEnabled,
 	}
 
 	if diff := deep.Equal(config, expected); diff != nil {

--- a/opsmngr/file_system_store_config_test.go
+++ b/opsmngr/file_system_store_config_test.go
@@ -27,6 +27,8 @@ func TestFileSystemStoreConfigServiceOp_List(t *testing.T) {
 	defer teardown()
 
 	assignmentEnabled := true
+	loadFactor := int64(50)
+
 	mux.HandleFunc("/admin/backup/snapshot/fileSystemConfigs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		_, _ = fmt.Fprint(w, `{
@@ -51,11 +53,13 @@ func TestFileSystemStoreConfigServiceOp_List(t *testing.T) {
 	expected := &FileSystemStoreConfigurations{
 		Results: []*FileSystemStoreConfiguration{
 			{
-				AdminBackupConfig: AdminBackupConfig{
-					ID:     ID,
-					Labels: []string{"l1", "l2"},
+				BackupStore: BackupStore{
+					AdminBackupConfig: AdminBackupConfig{
+						ID:     ID,
+						Labels: []string{"l1", "l2"},
+					},
+					LoadFactor: &loadFactor,
 				},
-				LoadFactor:               50,
 				MMAPV1CompressionSetting: "NONE",
 				StorePath:                "/data/backup",
 				WTCompressionSetting:     "ZLIB",
@@ -74,6 +78,8 @@ func TestFileSystemStoreConfigServiceOp_Get(t *testing.T) {
 	defer teardown()
 
 	assignmentEnabled := true
+	loadFactor := int64(50)
+
 	mux.HandleFunc(fmt.Sprintf("/admin/backup/snapshot/fileSystemConfigs/%s", ID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		_, _ = fmt.Fprint(w, `{
@@ -93,11 +99,13 @@ func TestFileSystemStoreConfigServiceOp_Get(t *testing.T) {
 	}
 
 	expected := &FileSystemStoreConfiguration{
-		AdminBackupConfig: AdminBackupConfig{
-			ID:     ID,
-			Labels: []string{"l1", "l2"},
+		BackupStore: BackupStore{
+			AdminBackupConfig: AdminBackupConfig{
+				ID:     ID,
+				Labels: []string{"l1", "l2"},
+			},
+			LoadFactor: &loadFactor,
 		},
-		LoadFactor:               50,
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
@@ -112,7 +120,9 @@ func TestFileSystemStoreConfigServiceOp_Get(t *testing.T) {
 func TestFileSystemStoreConfigServiceOp_Create(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
+
 	assignmentEnabled := true
+	loadFactor := int64(50)
 
 	mux.HandleFunc("/admin/backup/snapshot/fileSystemConfigs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -128,11 +138,13 @@ func TestFileSystemStoreConfigServiceOp_Create(t *testing.T) {
 	})
 
 	fileSystem := &FileSystemStoreConfiguration{
-		AdminBackupConfig: AdminBackupConfig{
-			ID:     ID,
-			Labels: []string{"l1", "l2"},
+		BackupStore: BackupStore{
+			AdminBackupConfig: AdminBackupConfig{
+				ID:     ID,
+				Labels: []string{"l1", "l2"},
+			},
+			LoadFactor: &loadFactor,
 		},
-		LoadFactor:               50,
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
@@ -145,11 +157,13 @@ func TestFileSystemStoreConfigServiceOp_Create(t *testing.T) {
 	}
 
 	expected := &FileSystemStoreConfiguration{
-		AdminBackupConfig: AdminBackupConfig{
-			ID:     ID,
-			Labels: []string{"l1", "l2"},
+		BackupStore: BackupStore{
+			AdminBackupConfig: AdminBackupConfig{
+				ID:     ID,
+				Labels: []string{"l1", "l2"},
+			},
+			LoadFactor: &loadFactor,
 		},
-		LoadFactor:               50,
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
@@ -164,7 +178,9 @@ func TestFileSystemStoreConfigServiceOp_Create(t *testing.T) {
 func TestFileSystemStoreConfigServiceOp_Update(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
+
 	assignmentEnabled := true
+	loadFactor := int64(50)
 
 	mux.HandleFunc(fmt.Sprintf("/admin/backup/snapshot/fileSystemConfigs/%s", ID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -180,11 +196,13 @@ func TestFileSystemStoreConfigServiceOp_Update(t *testing.T) {
 	})
 
 	fileSystem := &FileSystemStoreConfiguration{
-		AdminBackupConfig: AdminBackupConfig{
-			ID:     ID,
-			Labels: []string{"l1", "l2"},
+		BackupStore: BackupStore{
+			AdminBackupConfig: AdminBackupConfig{
+				ID:     ID,
+				Labels: []string{"l1", "l2"},
+			},
+			LoadFactor: &loadFactor,
 		},
-		LoadFactor:               50,
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",
@@ -197,11 +215,17 @@ func TestFileSystemStoreConfigServiceOp_Update(t *testing.T) {
 	}
 
 	expected := &FileSystemStoreConfiguration{
-		AdminBackupConfig: AdminBackupConfig{
-			ID:     ID,
-			Labels: []string{"l1", "l2"},
+		BackupStore: BackupStore{
+			AdminBackupConfig: AdminBackupConfig{
+				ID:     ID,
+				Labels: []string{"l1", "l2"},
+			},
+			LoadFactor:    &loadFactor,
+			MaxCapacityGB: nil,
+			Provisioned:   nil,
+			SyncSource:    "",
+			Username:      "",
 		},
-		LoadFactor:               50,
 		MMAPV1CompressionSetting: "NONE",
 		StorePath:                "/data/backup",
 		WTCompressionSetting:     "ZLIB",


### PR DESCRIPTION

<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-74339

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

Closes #[issue number]

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
