### PR TITLE
fix: shutdown and remove for sharded clusters now works for config rs and mongos

### DIFF
--- a/atmcfg/atmcfg.go
+++ b/atmcfg/atmcfg.go
@@ -57,8 +57,17 @@ func setDisabledByShardName(out *opsmngr.AutomationConfig, name string, disabled
 	})
 	if found {
 		s := out.Sharding[i]
+		// disable shards
 		for _, rs := range s.Shards {
 			setDisabledByReplicaSetName(out, rs.ID, disabled)
+		}
+		// disable config rs
+		setDisabledByReplicaSetName(out, s.ConfigServerReplica, disabled)
+		// disable mongos
+		for i := range out.Processes {
+			if out.Processes[i].Cluster == name {
+				out.Processes[i].Disabled = disabled
+			}
 		}
 	}
 }
@@ -140,8 +149,17 @@ func removeByShardName(out *opsmngr.AutomationConfig, name string) {
 	if found {
 		s := out.Sharding[i]
 		out.Sharding = append(out.Sharding[:i], out.Sharding[i+1:]...)
+		// remove shards
 		for _, rs := range s.Shards {
 			removeByReplicaSetName(out, rs.ID)
+		}
+		// remove config rs
+		removeByReplicaSetName(out, s.ConfigServerReplica)
+		// remove mongos
+		for j := range out.Processes {
+			if out.Processes[j].Cluster == name {
+				out.Processes = append(out.Processes[:j], out.Processes[j+1:]...)
+			}
 		}
 	}
 }

--- a/atmcfg/atmcfg_test.go
+++ b/atmcfg/atmcfg_test.go
@@ -322,7 +322,6 @@ func TestRemoveByClusterName(t *testing.T) {
 
 		RemoveByClusterName(config, clusterName)
 		if len(config.Processes) != 0 {
-			t.Errorf("%#v", config.Processes[0])
 			t.Errorf("RemoveByClusterName\n got=%#v\nwant=0\n", len(config.Processes))
 		}
 	})

--- a/atmcfg/atmcfg_test.go
+++ b/atmcfg/atmcfg_test.go
@@ -105,6 +105,63 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 				ProcessType: "mongod",
 				Version:     "4.2.2",
 			},
+			{
+				Args26: opsmngr.Args26{
+					NET: opsmngr.Net{
+						Port: 27019,
+					},
+					Replication: &opsmngr.Replication{
+						ReplSetName: name + "_configRS",
+					},
+					Sharding: &opsmngr.Sharding{
+						ClusterRole: "configsvr",
+					},
+					Storage: &opsmngr.Storage{
+						DBPath: "/data/db/",
+					},
+					SystemLog: opsmngr.SystemLog{
+						Destination: "file",
+						Path:        "/data/db/mongodb.log",
+					},
+				},
+				AuthSchemaVersion:           5,
+				Name:                        name + "_configRS_0",
+				Disabled:                    disabled,
+				FeatureCompatibilityVersion: "4.2",
+				Hostname:                    "host2",
+				LogRotate: &opsmngr.LogRotate{
+					SizeThresholdMB:  1000,
+					TimeThresholdHrs: 24,
+				},
+				ProcessType: "mongod",
+				Version:     "4.2.2",
+			},
+			{
+				Args26: opsmngr.Args26{
+					NET: opsmngr.Net{
+						Port: 27018,
+					},
+					Replication: nil,
+					Sharding:    nil,
+					Storage:     nil,
+					SystemLog: opsmngr.SystemLog{
+						Destination: "file",
+						Path:        "/data/db/mongos.log",
+					},
+				},
+				AuthSchemaVersion:           5,
+				Cluster:                     name,
+				Name:                        name + "_mongos_0",
+				Disabled:                    disabled,
+				FeatureCompatibilityVersion: "4.2",
+				Hostname:                    "host1",
+				LogRotate: &opsmngr.LogRotate{
+					SizeThresholdMB:  1000,
+					TimeThresholdHrs: 24,
+				},
+				ProcessType: "mongos",
+				Version:     "4.2.2",
+			},
 		},
 		ReplicaSets: []*opsmngr.ReplicaSet{
 			{
@@ -122,10 +179,26 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 					},
 				},
 			},
+			{
+				ID:              name + "_configRS",
+				ProtocolVersion: "1",
+				Members: []opsmngr.Member{
+					{
+						ArbiterOnly:  false,
+						BuildIndexes: true,
+						Hidden:       false,
+						Host:         name + "_configRS_0",
+						Priority:     1,
+						SlaveDelay:   0,
+						Votes:        1,
+					},
+				},
+			},
 		},
 		Sharding: []*opsmngr.ShardingConfig{
 			{
-				Name: name,
+				Name:                name,
+				ConfigServerReplica: name + "_configRS",
 				Shards: []*opsmngr.Shard{
 					{
 						ID: name + "_shard_0",
@@ -206,8 +279,10 @@ func TestShutdown(t *testing.T) {
 	t.Run("sharded cluster", func(t *testing.T) {
 		config := automationConfigWithOneShardedCluster(clusterName, false)
 		Shutdown(config, clusterName)
-		if !config.Processes[0].Disabled {
-			t.Errorf("TestShutdown\n got=%#v\nwant=%#v\n", config.Processes[0].Disabled, true)
+		for i := range config.Processes {
+			if !config.Processes[i].Disabled {
+				t.Errorf("TestShutdown\n got=%#v\nwant=%#v\n", config.Processes[i].Disabled, true)
+			}
 		}
 	})
 }
@@ -225,8 +300,10 @@ func TestStartup(t *testing.T) {
 		config := automationConfigWithOneShardedCluster(clusterName, true)
 
 		Startup(config, clusterName)
-		if config.Processes[0].Disabled {
-			t.Errorf("TestStartup\n got=%#v\nwant=%#v\n", config.Processes[0].Disabled, false)
+		for i := range config.Processes {
+			if config.Processes[i].Disabled {
+				t.Errorf("TestStartup\n got=%#v\nwant=%#v\n", config.Processes[i].Disabled, false)
+			}
 		}
 	})
 }
@@ -245,6 +322,7 @@ func TestRemoveByClusterName(t *testing.T) {
 
 		RemoveByClusterName(config, clusterName)
 		if len(config.Processes) != 0 {
+			t.Errorf("%#v", config.Processes[0])
 			t.Errorf("RemoveByClusterName\n got=%#v\nwant=0\n", len(config.Processes))
 		}
 	})


### PR DESCRIPTION
## Proposed changes

While testing the CLI for an advance remove command, https://github.com/mongodb/mongocli/pull/510, I realized we have a bug in shutdown for sharded clusters where mongos and config rs are left unmodified. 

Fixing this and adding tests to catch it also exposed the same bug for the remove method, so here we are fixing two bugs for one

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

