### PR TITLE
CLOUDP-76488: [mongocli] patching the automation config can produce random network errors

### DIFF
--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -292,7 +293,20 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*atl
 		c.onRequestCompleted(req, resp)
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		// Ensure the response body is fully read and closed
+		// before we reconnect, so that we reuse the same TCP connection.
+		// Close the previous response's body. But read at least some of
+		// the body so if it's small the underlying TCP connection will be
+		// re-used. No need to check for errors: if it fails, the Transport
+		// won't reuse it anyway.
+		const maxBodySlurpSize = 2 << 10
+		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+			_, _ = io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+		}
+
+		resp.Body.Close()
+	}()
 
 	response := &atlas.Response{Response: resp}
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-76488

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This solve one of the network errors but broken pipe seems to still be a problem 