### PR TITLE
CLOUDP-77074: [go-client] allow to disable monitoring/backup

### DIFF
--- a/atmcfg/atmcfg.go
+++ b/atmcfg/atmcfg.go
@@ -84,7 +84,7 @@ func Startup(out *opsmngr.AutomationConfig, name string) {
 
 const monitoringVersion = "7.2.0.488-1" // Last monitoring version released
 
-// EnableMonitoring enables all processes of the given cluster name
+// EnableMonitoring enables monitoring for the given hostname
 func EnableMonitoring(out *opsmngr.AutomationConfig, hostname string) error {
 	for _, v := range out.MonitoringVersions {
 		if v.Hostname == hostname {
@@ -98,9 +98,20 @@ func EnableMonitoring(out *opsmngr.AutomationConfig, hostname string) error {
 	return nil
 }
 
+// DisableMonitoring disables monitoring for the given hostname
+func DisableMonitoring(out *opsmngr.AutomationConfig, hostname string) error {
+	for i, v := range out.MonitoringVersions {
+		if v.Hostname == hostname {
+			out.MonitoringVersions = append(out.MonitoringVersions[:i], out.MonitoringVersions[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("no monitoring for '%s'", hostname)
+}
+
 const backupVersion = "7.8.1.1109-1" // Last backup version released
 
-// EnableMonitoring enables all processes of the given cluster name
+// EnableMonitoring enables backup for the given hostname
 func EnableBackup(out *opsmngr.AutomationConfig, hostname string) error {
 	for _, v := range out.BackupVersions {
 		if v.Hostname == hostname {
@@ -112,6 +123,17 @@ func EnableBackup(out *opsmngr.AutomationConfig, hostname string) error {
 		Hostname: hostname,
 	})
 	return nil
+}
+
+// DisableBackup disables backup for the given hostname
+func DisableBackup(out *opsmngr.AutomationConfig, hostname string) error {
+	for i, v := range out.BackupVersions {
+		if v.Hostname == hostname {
+			out.BackupVersions = append(out.BackupVersions[:i], out.BackupVersions[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("no backup for '%s'", hostname)
 }
 
 // RemoveByClusterName removes a cluster and its associated processes from the config.

--- a/atmcfg/atmcfg.go
+++ b/atmcfg/atmcfg.go
@@ -111,7 +111,7 @@ func DisableMonitoring(out *opsmngr.AutomationConfig, hostname string) error {
 
 const backupVersion = "7.8.1.1109-1" // Last backup version released
 
-// EnableMonitoring enables backup for the given hostname
+// EnableBackup enables backup for the given hostname
 func EnableBackup(out *opsmngr.AutomationConfig, hostname string) error {
 	for _, v := range out.BackupVersions {
 		if v.Hostname == hostname {

--- a/atmcfg/atmcfg_test.go
+++ b/atmcfg/atmcfg_test.go
@@ -538,6 +538,52 @@ func TestEnableMonitoring(t *testing.T) {
 	}
 }
 
+func TestDisableMonitoring(t *testing.T) {
+	type args struct {
+		out      *opsmngr.AutomationConfig
+		hostname string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "empty config",
+			args: args{
+				out:      &opsmngr.AutomationConfig{},
+				hostname: "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty config",
+			args: args{
+				out: &opsmngr.AutomationConfig{
+					MonitoringVersions: []*opsmngr.ConfigVersion{
+						{
+							Name:     "1",
+							Hostname: "test",
+						},
+					},
+				},
+				hostname: "test",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		out := tt.args.out
+		hostname := tt.args.hostname
+		wantErr := tt.wantErr
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DisableMonitoring(out, hostname); (err != nil) != wantErr {
+				t.Errorf("EnableMonitoring() error = %v, wantErr %v", err, wantErr)
+			}
+		})
+	}
+}
+
 func TestEnableBackup(t *testing.T) {
 	type args struct {
 		out      *opsmngr.AutomationConfig
@@ -578,6 +624,52 @@ func TestEnableBackup(t *testing.T) {
 		wantErr := tt.wantErr
 		t.Run(tt.name, func(t *testing.T) {
 			if err := EnableBackup(out, hostname); (err != nil) != wantErr {
+				t.Errorf("EnableBackup() error = %v, wantErr %v", err, wantErr)
+			}
+		})
+	}
+}
+
+func TestDisableBackup(t *testing.T) {
+	type args struct {
+		out      *opsmngr.AutomationConfig
+		hostname string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "empty config",
+			args: args{
+				out:      &opsmngr.AutomationConfig{},
+				hostname: "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty config",
+			args: args{
+				out: &opsmngr.AutomationConfig{
+					BackupVersions: []*opsmngr.ConfigVersion{
+						{
+							Name:     "1",
+							Hostname: "test",
+						},
+					},
+				},
+				hostname: "test",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		out := tt.args.out
+		hostname := tt.args.hostname
+		wantErr := tt.wantErr
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DisableBackup(out, hostname); (err != nil) != wantErr {
 				t.Errorf("EnableBackup() error = %v, wantErr %v", err, wantErr)
 			}
 		})


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-77074

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

I implemented this as a quick way to test the automation config endpoint via disabling/enabling monitoring