### PR TITLE
Fix fields values. Add raw config getter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/xdg-go/stringprep v1.0.0
 	github.com/xdg/stringprep v1.0.0 // indirect
-	go.mongodb.org/atlas v0.5.1-0.20201007214134-b315fe7503d2
+	go.mongodb.org/atlas v0.5.1-0.20201120132859-b5ba231a0e45
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/xdg-go/stringprep v1.0.0 h1:W/PJi55zhi8ClBDgGZK2sdhe6QxuHS6YiVwrGEOYj
 github.com/xdg-go/stringprep v1.0.0/go.mod h1:1lAKNhwXFE4//YT4gqVxkhclqvPTWe2Kyd6L59AbR8w=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
-go.mongodb.org/atlas v0.5.1-0.20201007214134-b315fe7503d2 h1:b4Ng7d2sCSgYKwLMOetbwLcPE732SiBnJqH5rQrhZOs=
-go.mongodb.org/atlas v0.5.1-0.20201007214134-b315fe7503d2/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
+go.mongodb.org/atlas v0.5.1-0.20201120132859-b5ba231a0e45 h1:4UTKdo6Bc+Lw8iiAneVlExtATg5zYQsa/5ytxtd5biU=
+go.mongodb.org/atlas v0.5.1-0.20201120132859-b5ba231a0e45/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=

--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -15,9 +15,7 @@
 package opsmngr
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -38,14 +36,8 @@ func (s *AutomationServiceOp) GetConfig(ctx context.Context, groupID string) (*A
 		return nil, nil, err
 	}
 
-	body := new(bytes.Buffer)
-	resp, err := s.Client.Do(ctx, req, body)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	root := &AutomationConfig{raw: body.Bytes()}
-	err = json.NewDecoder(body).Decode(root)
+	root := new(AutomationConfig)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -103,12 +95,6 @@ type AutomationConfig struct {
 	TLS                  *SSL                      `json:"tls,omitempty"`
 	UIBaseURL            *string                   `json:"uiBaseUrl,omitempty"`
 	Version              int                       `json:"version,omitempty"`
-	raw                  []byte
-}
-
-// Raw returns original Automation Config in bytes.
-func (ac *AutomationConfig) Raw() []byte {
-	return ac.raw
 }
 
 type ConfigVersion struct {

--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -15,7 +15,9 @@
 package opsmngr
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -36,8 +38,14 @@ func (s *AutomationServiceOp) GetConfig(ctx context.Context, groupID string) (*A
 		return nil, nil, err
 	}
 
-	root := new(AutomationConfig)
-	resp, err := s.Client.Do(ctx, req, root)
+	body := new(bytes.Buffer)
+	resp, err := s.Client.Do(ctx, req, body)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	root := &AutomationConfig{raw: body.Bytes()}
+	err = json.NewDecoder(body).Decode(root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -71,6 +79,8 @@ func (s *AutomationServiceOp) UpdateConfig(ctx context.Context, groupID string, 
 // See more: https://docs.opsmanager.mongodb.com/current/reference/cluster-configuration/
 type AutomationConfig struct {
 	AgentVersion         *map[string]interface{}   `json:"agentVersion,omitempty"`
+	AtlasProxies         *[]interface{}            `json:"atlasProxies,omitempty"`
+	Filebeat             *map[string]interface{}   `json:"filebeat,omitempty"`
 	Auth                 Auth                      `json:"auth"`
 	BackupVersions       []*ConfigVersion          `json:"backupVersions"`
 	Balancer             *map[string]interface{}   `json:"balancer"`
@@ -80,10 +90,10 @@ type AutomationConfig struct {
 	LDAP                 *map[string]interface{}   `json:"ldap,omitempty"`
 	MongoDBToolsVersion  *map[string]interface{}   `json:"mongoDbToolsVersion,omitempty"`
 	MongoDBVersions      []*map[string]interface{} `json:"mongoDbVersions,omitempty"`
-	MongoSQLDs           []*map[string]interface{} `json:"mongosqlds,omitempty"`
+	MongoSQLDs           []*map[string]interface{} `json:"mongosqlds"`
 	MonitoringVersions   []*ConfigVersion          `json:"monitoringVersions,omitempty"`
-	OnlineArchiveModules []*map[string]interface{} `json:"onlineArchiveModules,omitempty"`
-	MongoTS              []*map[string]interface{} `json:"mongots,omitempty"`
+	OnlineArchiveModules []*map[string]interface{} `json:"onlineArchiveModules"`
+	MongoTS              []*map[string]interface{} `json:"mongots"`
 	Options              *map[string]interface{}   `json:"options"`
 	Processes            []*Process                `json:"processes"`
 	ReplicaSets          []*ReplicaSet             `json:"replicaSets"`
@@ -91,8 +101,14 @@ type AutomationConfig struct {
 	Sharding             []*ShardingConfig         `json:"sharding"`
 	SSL                  *SSL                      `json:"ssl,omitempty"`
 	TLS                  *SSL                      `json:"tls,omitempty"`
-	UIBaseURL            *string                   `json:"uiBaseUrl"`
+	UIBaseURL            *string                   `json:"uiBaseUrl,omitempty"`
 	Version              int                       `json:"version,omitempty"`
+	raw                  []byte
+}
+
+// Raw returns original Automation Config in bytes.
+func (ac *AutomationConfig) Raw() []byte {
+	return ac.raw
 }
 
 type ConfigVersion struct {
@@ -173,6 +189,7 @@ type Args26 struct {
 // MongoDBUser database user
 type MongoDBUser struct {
 	AuthenticationRestrictions []string       `json:"authenticationRestrictions"`
+	CustomData                 interface{}    `json:"customData,omitempty"`
 	Database                   string         `json:"db"`
 	InitPassword               string         `json:"initPwd,omitempty"` // The cleartext password to be assigned to the user
 	Mechanisms                 []string       `json:"mechanisms"`
@@ -206,7 +223,7 @@ type Member struct {
 	Host         string                  `json:"host"`
 	Priority     float64                 `json:"priority"`
 	SlaveDelay   float64                 `json:"slaveDelay"`
-	Tags         *map[string]interface{} `json:"tags"`
+	Tags         *map[string]interface{} `json:"tags,omitempty"`
 	Votes        float64                 `json:"votes"`
 }
 

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -172,7 +172,6 @@ const jsonBlob = `{
     "protocolVersion" : "1",
     "settings" : { }
   } ],
-  "uiBaseUrl" : null,
   "version" : 1
 }`
 

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -189,6 +189,10 @@ func TestAutomation_GetConfig(t *testing.T) {
 		t.Fatalf("Automation.GetConfig returned error: %v", err)
 	}
 
+	if string(config.Raw()) != jsonBlob {
+		t.Fatalf("Raw returned config isn't equal origin")
+	}
+
 	expected := &AutomationConfig{
 		Auth: Auth{
 			AutoAuthMechanism: "MONGODB-CR",

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -189,10 +189,6 @@ func TestAutomation_GetConfig(t *testing.T) {
 		t.Fatalf("Automation.GetConfig returned error: %v", err)
 	}
 
-	if string(config.Raw()) != jsonBlob {
-		t.Fatalf("Raw returned config isn't equal origin")
-	}
-
 	expected := &AutomationConfig{
 		Auth: Auth{
 			AutoAuthMechanism: "MONGODB-CR",


### PR DESCRIPTION
## Proposed changes

- add support to get raw automation config data (allow users to make config backup/compare changes in config)
- `.atlasProxies`/`.filebeat` to support cloud manager automation config
- `.mongosqlds`/`.onlineArchiveModules`/`.mongots` should not be tagged as `omitempty` to prevent unnecessary changes in automation config
- `.uiBaseUrl`/`.replicaSets.members.[].Tags`  should be tagged as `omitempty` to prevent unnecessary changes in automation config
- `.auth.usersDelete.customData`/`.auth.usersWanted.customData` to fully support ops manager automation config

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
