### PR TITLE
CLOUDP-89947: Add new memberConfig's secondaryDelaySecs field for FCV > 5

### DIFF
--- a/atmcfg/fixtures.go
+++ b/atmcfg/fixtures.go
@@ -10,6 +10,7 @@ const (
 )
 
 func automationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.AutomationConfig {
+	slaveDelay := float64(0)
 	return &opsmngr.AutomationConfig{
 		Processes: []*opsmngr.Process{
 			{
@@ -53,7 +54,7 @@ func automationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 						Hidden:       false,
 						Host:         name + "_0",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 				},
@@ -65,6 +66,7 @@ func automationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.AutomationConfig {
 	configRSPort := defaultMongoPort + 1
 	mongosPort := configRSPort + 1
+	slaveDelay := float64(0)
 	return &opsmngr.AutomationConfig{
 		Processes: []*opsmngr.Process{
 			{
@@ -165,7 +167,7 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 						Hidden:       false,
 						Host:         name + "_shard_0_0",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 				},
@@ -180,7 +182,7 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 						Hidden:       false,
 						Host:         name + "_configRS_0",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 				},

--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -202,15 +202,16 @@ type ScramShaCreds struct {
 
 // Member configs
 type Member struct {
-	ID           int                     `json:"_id"`
-	ArbiterOnly  bool                    `json:"arbiterOnly"`
-	BuildIndexes bool                    `json:"buildIndexes"`
-	Hidden       bool                    `json:"hidden"`
-	Host         string                  `json:"host"`
-	Priority     float64                 `json:"priority"`
-	SlaveDelay   float64                 `json:"slaveDelay"`
-	Tags         *map[string]interface{} `json:"tags,omitempty"`
-	Votes        float64                 `json:"votes"`
+	ID                 int                     `json:"_id"`
+	ArbiterOnly        bool                    `json:"arbiterOnly"`
+	BuildIndexes       bool                    `json:"buildIndexes"`
+	Hidden             bool                    `json:"hidden"`
+	Host               string                  `json:"host"`
+	Priority           float64                 `json:"priority"`
+	SlaveDelay         *float64                `json:"slaveDelay,omitempty"`
+	SecondaryDelaySecs *float64                `json:"secondaryDelaySecs,omitempty"`
+	Tags               *map[string]interface{} `json:"tags,omitempty"`
+	Votes              float64                 `json:"votes"`
 }
 
 // ReplicaSet configs

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -189,6 +189,7 @@ func TestAutomation_GetConfig(t *testing.T) {
 		t.Fatalf("Automation.GetConfig returned error: %v", err)
 	}
 
+	slaveDelay := float64(0)
 	expected := &AutomationConfig{
 		Auth: Auth{
 			AutoAuthMechanism: "MONGODB-CR",
@@ -329,7 +330,7 @@ func TestAutomation_GetConfig(t *testing.T) {
 						Hidden:       false,
 						Host:         "myReplicaSet_1",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 					{
@@ -339,7 +340,7 @@ func TestAutomation_GetConfig(t *testing.T) {
 						Hidden:       false,
 						Host:         "myReplicaSet_2",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 					{
@@ -349,7 +350,7 @@ func TestAutomation_GetConfig(t *testing.T) {
 						Hidden:       false,
 						Host:         "myReplicaSet_3",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 				},
@@ -368,6 +369,7 @@ func TestAutomation_UpdateConfig(t *testing.T) {
 	defer teardown()
 
 	clusterName := "myReplicaSet"
+	slaveDelay := float64(0)
 	updateRequest := &AutomationConfig{
 		Auth: Auth{
 			AutoAuthMechanism: "MONGODB-CR",
@@ -480,7 +482,7 @@ func TestAutomation_UpdateConfig(t *testing.T) {
 						Hidden:       false,
 						Host:         "myReplicaSet_1",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 					{
@@ -490,7 +492,7 @@ func TestAutomation_UpdateConfig(t *testing.T) {
 						Hidden:       false,
 						Host:         "myReplicaSet_2",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 					{
@@ -500,7 +502,7 @@ func TestAutomation_UpdateConfig(t *testing.T) {
 						Hidden:       false,
 						Host:         "myReplicaSet_3",
 						Priority:     1,
-						SlaveDelay:   0,
+						SlaveDelay:   &slaveDelay,
 						Votes:        1,
 					},
 				},

--- a/search/example_search_test.go
+++ b/search/example_search_test.go
@@ -23,6 +23,8 @@ import (
 
 const rsName = "myReplicaSet_1"
 
+var slaveDelay = float64(0)
+
 var fixture = &opsmngr.AutomationConfig{
 	Auth: opsmngr.Auth{
 		AutoAuthMechanism: "MONGODB-CR",
@@ -149,7 +151,7 @@ var fixture = &opsmngr.AutomationConfig{
 					Hidden:       false,
 					Host:         rsName,
 					Priority:     1,
-					SlaveDelay:   0,
+					SlaveDelay:   &slaveDelay,
 					Votes:        1,
 				},
 				{
@@ -159,7 +161,7 @@ var fixture = &opsmngr.AutomationConfig{
 					Hidden:       false,
 					Host:         "myReplicaSet_2",
 					Priority:     1,
-					SlaveDelay:   0,
+					SlaveDelay:   &slaveDelay,
 					Votes:        1,
 				},
 				{
@@ -169,7 +171,7 @@ var fixture = &opsmngr.AutomationConfig{
 					Hidden:       false,
 					Host:         "myReplicaSet_3",
 					Priority:     1,
-					SlaveDelay:   0,
+					SlaveDelay:   &slaveDelay,
 					Votes:        1,
 				},
 			},


### PR DESCRIPTION
## Proposed changes

Field `slaveDelay` is going to be replaced by `secondaryDelaySecs`. Let's support both of them
Doc changes: https://github.com/mongodb/docs/commit/bfcde5ee32c1857b744fcbc1693123220beaa06a
Related doc changes ticket: https://jira.mongodb.org/browse/DOCS-14169

_Jira ticket:_ 

https://jira.mongodb.org/browse/CLOUDP-89947

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code