### PR TITLE
CLOUDP-92485: Add AutoPEMKeyFilePwd to automation config

### DIFF
--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -133,6 +133,7 @@ type IndexConfig struct {
 // SSL config properties.
 type SSL struct {
 	AutoPEMKeyFilePath    string `json:"autoPEMKeyFilePath,omitempty"` //nolint:tagliatelle // correct from API
+	AutoPEMKeyFilePwd     string `json:"autoPEMKeyFilePwd,omitempty"`  //nolint:tagliatelle // correct from API
 	CAFilePath            string `json:"CAFilePath,omitempty"`         //nolint:tagliatelle // correct from API
 	ClientCertificateMode string `json:"clientCertificateMode,omitempty"`
 }


### PR DESCRIPTION
## Proposed changes ##
Add AutoPEMKeyFilePwd  to AutomationConfig.

_Jira ticket:_  https://jira.mongodb.org/browse/CLOUDP-92485

AutoPEMKeyFilePwd is not being pared by GET calls from Ops Manager. As a result, subsequent PUT requests will clear the existing config value and remove the password setting.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
