### PR TITLE
test: test actions with only major version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,11 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.40.1
+          version: v1.41.1
 
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
@@ -27,13 +27,13 @@ jobs:
           - 1.16
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.golang }}
       - name: Cache Dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.golang }}-${{ hashFiles('**/go.sum') }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
 SOURCE_FILES?=./...
-GOLANGCI_VERSION=v1.40.1
+GOLANGCI_VERSION=v1.41.1
 COVERAGE=coverage.out
 
 export PATH := ./bin:$(PATH)


### PR DESCRIPTION
## Proposed changes

Github recomments to just use the major, I think this got bumped as par of dependabot let's see if dependabot stops trying to add minor versions here