### PR TITLE
Fixed the endpoint that allows to update an invitation for organisation

### DIFF
--- a/opsmngr/organization_invitations.go
+++ b/opsmngr/organization_invitations.go
@@ -142,11 +142,11 @@ func (s *OrganizationsServiceOp) DeleteInvitation(ctx context.Context, orgID, in
 	return resp, err
 }
 
-func (s *OrganizationsServiceOp) updateInvitation(ctx context.Context, orgID, invitatioID string, invitation *atlas.Invitation) (*atlas.Invitation, *Response, error) {
+func (s *OrganizationsServiceOp) updateInvitation(ctx context.Context, orgID, invitationID string, invitation *atlas.Invitation) (*atlas.Invitation, *Response, error) {
 	path := fmt.Sprintf(invitationBasePath, orgID)
 
-	if invitatioID != "" {
-		path = fmt.Sprintf("%s/%s", path, invitation.ID)
+	if invitationID != "" {
+		path = fmt.Sprintf("%s/%s", path, invitationID)
 	}
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, invitation)

--- a/opsmngr/project_invitations.go
+++ b/opsmngr/project_invitations.go
@@ -160,7 +160,7 @@ func (s *ProjectsServiceOp) updateInvitation(ctx context.Context, groupID, invit
 	path := fmt.Sprintf(projectInvitationBasePath, groupID)
 
 	if invitationID != "" {
-		path = fmt.Sprintf("%s/%s", path, invitation.ID)
+		path = fmt.Sprintf("%s/%s", path, invitationID)
 	}
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, invitation)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->
Bug: we were setting the wrong `invitationID`

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ 

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
