### PR TITLE
CLOUDP-94859: allow to reclaim free space for processes [ops manager go client]

### DIFF
--- a/atmcfg/atmcfg.go
+++ b/atmcfg/atmcfg.go
@@ -559,25 +559,30 @@ func Restart(out *opsmngr.AutomationConfig, name string) {
 
 // ReclaimFreeSpace sets all process of a cluster to reclaim free space.
 func ReclaimFreeSpace(out *opsmngr.AutomationConfig, clusterName string) {
+	ReclaimFreeSpaceWithLastCompact(out, clusterName, "")
+}
+
+func ReclaimFreeSpaceWithLastCompact(out *opsmngr.AutomationConfig, clusterName, lastCompact string) {
+	if lastCompact == "" {
+		lastCompact = time.Now().Format(time.RFC3339)
+	}
 	newDeploymentAuthMechanisms(out)
-	lastCompact := time.Now().Format(time.RFC3339)
 	reclaimByReplicaSetName(out, clusterName, lastCompact)
 	reclaimByShardName(out, clusterName, lastCompact)
 }
 
 // ReclaimFreeSpaceForProcessesByClusterName reclaims free space for a cluster. Processes are provided in the format {"hostname:port","hostname2:port2"}.
-func ReclaimFreeSpaceForProcessesByClusterName(out *opsmngr.AutomationConfig, clusterName string, processes []string) error {
+func ReclaimFreeSpaceForProcessesByClusterName(out *opsmngr.AutomationConfig, clusterName, lastCompact string, processes []string) error {
 	if len(processes) == 0 {
-		ReclaimFreeSpace(out, clusterName)
+		ReclaimFreeSpaceWithLastCompact(out, clusterName, lastCompact)
 		return nil
 	}
 
-	return reclaimFreeSpaceForProcesses(out, clusterName, processes)
+	return reclaimFreeSpaceForProcesses(out, clusterName, lastCompact, processes)
 }
 
-func reclaimFreeSpaceForProcesses(out *opsmngr.AutomationConfig, clusterName string, processes []string) error {
+func reclaimFreeSpaceForProcesses(out *opsmngr.AutomationConfig, clusterName, lastCompact string, processes []string) error {
 	newDeploymentAuthMechanisms(out)
-	lastCompact := time.Now().Format(time.RFC3339)
 	processesMap := newProcessMap(processes)
 	reclaimByReplicaSetNameAndProcesses(out, processesMap, clusterName, lastCompact)
 	reclaimByShardNameAndProcesses(out, processesMap, clusterName, lastCompact)

--- a/atmcfg/atmcfg_test.go
+++ b/atmcfg/atmcfg_test.go
@@ -17,6 +17,7 @@ package atmcfg
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"go.mongodb.org/ops-manager/opsmngr"
 )
@@ -695,9 +696,10 @@ func TestReclaimFreeSpace(t *testing.T) {
 }
 
 func TestReclaimFreeSpaceForProcessesByClusterName(t *testing.T) {
+	lastCompact := time.Now().Format(time.RFC3339)
 	t.Run("replica set", func(t *testing.T) {
 		config := automationConfigWithOneReplicaSet(clusterName, true)
-		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, []string{"host0:27017"})
+		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, lastCompact, []string{"host0:27017"})
 		if err != nil {
 			t.Fatalf("ReclaimFreeSpaceForProcessesByClusterName() returned an unexpected error: %v", err)
 		}
@@ -709,7 +711,7 @@ func TestReclaimFreeSpaceForProcessesByClusterName(t *testing.T) {
 
 	t.Run("sharded cluster - two processes", func(t *testing.T) {
 		config := automationConfigWithOneShardedCluster(clusterName, true)
-		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, []string{"host0:27017", "host2:27018"})
+		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, lastCompact, []string{"host0:27017", "host2:27018"})
 		if err != nil {
 			t.Fatalf("ReclaimFreeSpaceForProcessesByClusterName() returned an unexpected error: %v", err)
 		}
@@ -724,7 +726,7 @@ func TestReclaimFreeSpaceForProcessesByClusterName(t *testing.T) {
 	})
 	t.Run("restart entire sharded cluster", func(t *testing.T) {
 		config := automationConfigWithOneShardedCluster(clusterName, true)
-		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, nil)
+		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, lastCompact, nil)
 		if err != nil {
 			t.Fatalf("ReclaimFreeSpaceForProcessesByClusterName() returned an unexpected error: %v", err)
 		}
@@ -736,7 +738,7 @@ func TestReclaimFreeSpaceForProcessesByClusterName(t *testing.T) {
 	})
 	t.Run("provide a process that does not exist", func(t *testing.T) {
 		config := automationConfigWithOneShardedCluster(clusterName, true)
-		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, []string{"hostTest:21021"})
+		err := ReclaimFreeSpaceForProcessesByClusterName(config, clusterName, lastCompact, []string{"hostTest:21021"})
 		if !errors.Is(err, ErrProcessNotFound) {
 			t.Fatalf("Got = %#v, want = %#v", err, ErrProcessNotFound)
 		}


### PR DESCRIPTION


<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-94859

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
