### PR TITLE
CLOUDP-105826: Update golangci-lint to 1.43

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.0
+          version: v1.43.0
 
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
 SOURCE_FILES?=./...
-GOLANGCI_VERSION=v1.42.0
+GOLANGCI_VERSION=v1.43.0
 COVERAGE=coverage.out
 
 export PATH := ./bin:$(PATH)

--- a/opsmngr/accesslist_api_keys.go
+++ b/opsmngr/accesslist_api_keys.go
@@ -22,7 +22,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-const accessListAPIKeysPath = "api/public/v1.0/orgs/%s/apiKeys/%s/accessList"
+const accessListAPIKeysPath = "api/public/v1.0/orgs/%s/apiKeys/%s/accessList" //nolint:gosec // This is a path
 
 // AccessListAPIKeysServiceOp handles communication with the AccessList API keys related methods of the MongoDB Ops Manager API.
 type AccessListAPIKeysServiceOp service

--- a/opsmngr/accesslist_api_keys_test.go
+++ b/opsmngr/accesslist_api_keys_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	apiKeyID  = "API-KEY-ID"
+	apiKeyID  = "API-KEY-ID" //nolint:gosec // ID and not an actual key
 	ipAddress = "IP-ADDRESS"
 )
 

--- a/opsmngr/agents_api_keys.go
+++ b/opsmngr/agents_api_keys.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	agentAPIKeysBasePath = "api/public/v1.0/groups/%s/agentapikeys"
+	agentAPIKeysBasePath = "api/public/v1.0/groups/%s/agentapikeys" //nolint:gosec // This is a path
 )
 
 // AgentAPIKey defines the structure for an Agent API key.

--- a/opsmngr/global_api_key_whitelists.go
+++ b/opsmngr/global_api_key_whitelists.go
@@ -22,7 +22,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-const whitelistAPIKeysPath = "api/public/v1.0/admin/whitelist"
+const whitelistAPIKeysPath = "api/public/v1.0/admin/whitelist" //nolint:gosec // This is a path
 
 // GlobalAPIKeyWhitelistsService provides access to the global alerts related functions in the Ops Manager API.
 //

--- a/opsmngr/global_api_keys.go
+++ b/opsmngr/global_api_keys.go
@@ -23,7 +23,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-const apiKeysPath = "api/public/v1.0/admin/apiKeys"
+const apiKeysPath = "api/public/v1.0/admin/apiKeys" //nolint:gosec // This is a path
 
 // GlobalAPIKeysService provides access to the global alerts related functions in the Ops Manager API.
 //

--- a/opsmngr/global_api_keys_test.go
+++ b/opsmngr/global_api_keys_test.go
@@ -26,12 +26,11 @@ import (
 )
 
 const (
-	apiDesc    = "test-apikeye"
-	ewmaqvdo   = "ewmaqvdo"
-	testAPIKey = "test-apikey"
+	apiDesc        = "test-apikeye"
+	ewmaqvdo       = "ewmaqvdo"
+	testAPIKey     = "test-apikey"
+	globalAPIKeyID = "5c47503320eef5699e1cce8d" //nolint:gosec // ID and not an actual key
 )
-
-const globalAPIKeyID = "5c47503320eef5699e1cce8d"
 
 func TestAPIKeys_ListAPIKeys(t *testing.T) {
 	client, mux, teardown := setup()

--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -352,7 +351,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		// won't reuse it anyway.
 		const maxBodySlurpSize = 2 << 10
 		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
-			_, _ = io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+			_, _ = io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
 		}
 
 		resp.Body.Close()
@@ -375,7 +374,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		}
 
 		response.Raw = raw.Bytes()
-		body = ioutil.NopCloser(raw)
+		body = io.NopCloser(raw)
 	}
 
 	if v != nil {

--- a/opsmngr/opsmngr_test.go
+++ b/opsmngr/opsmngr_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -151,7 +151,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 	}
 
 	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if string(body) != outBody {
 		t.Errorf("NewRequest(%v)Body = %v, expected %v", inBody, string(body), outBody)
 	}

--- a/opsmngr/organization_api_keys.go
+++ b/opsmngr/organization_api_keys.go
@@ -23,7 +23,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-const apiKeysOrgPath = "api/public/v1.0/orgs/%s/apiKeys"
+const apiKeysOrgPath = "api/public/v1.0/orgs/%s/apiKeys" //nolint:gosec // This is a path
 
 // APIKeysServiceOp handles communication with the APIKey related methods
 // of the MongoDB Ops Manager API.

--- a/opsmngr/organization_api_keys_test.go
+++ b/opsmngr/organization_api_keys_test.go
@@ -255,8 +255,6 @@ func TestOrganizationAPIKeys_Create(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 
-	orgID := "1"
-
 	createRequest := &atlas.APIKeyInput{
 		Desc:  "test-apiKey",
 		Roles: []string{"GROUP_OWNER"},
@@ -320,8 +318,6 @@ func TestOrganizationAPIKeys_Update(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 
-	orgID := "1"
-
 	updateRequest := &atlas.APIKeyInput{
 		Desc:  "test-apiKey",
 		Roles: []string{"GROUP_OWNER"},
@@ -363,9 +359,6 @@ func TestOrganizationAPIKeys_Update(t *testing.T) {
 func TestOrganizationAPIKeys_Delete(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
-
-	orgID := "1"
-	apiKeyID := "5c47503320eef5699e1cce8d"
 
 	mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/orgs/%s/apiKeys/%s", orgID, apiKeyID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/opsmngr/organization_whitelist_api_keys.go
+++ b/opsmngr/organization_whitelist_api_keys.go
@@ -22,7 +22,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-const organizationWhitelistAPIKeysPath = "api/public/v1.0/orgs/%s/apiKeys/%s/whitelist"
+const organizationWhitelistAPIKeysPath = "api/public/v1.0/orgs/%s/apiKeys/%s/whitelist" //nolint:gosec // This is a path
 
 // WhitelistAPIKeysServiceOp handles communication with the Whitelist API keys related methods of the
 // MongoDB Ops Manager API.

--- a/opsmngr/organization_whitelist_api_keys_test.go
+++ b/opsmngr/organization_whitelist_api_keys_test.go
@@ -168,9 +168,6 @@ func TestOrganizationWhitelistAPIKeys_Create(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 
-	orgID := "ORG-ID"
-	apiKeyID := "API-KEY-ID"
-
 	createRequest := []*atlas.WhitelistAPIKeysReq{
 		{
 			IPAddress: "77.54.32.11",

--- a/opsmngr/project_api_keys.go
+++ b/opsmngr/project_api_keys.go
@@ -22,7 +22,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-const projectAPIKeysPath = "api/public/v1.0/groups/%s/apiKeys"
+const projectAPIKeysPath = "api/public/v1.0/groups/%s/apiKeys" //nolint:gosec // This is a path
 
 // ProjectAPIKeysOp handles communication with the APIKey related methods
 // of the MongoDB Ops Manager API.


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-105826

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments
Linting now flags `ioutil` as deprecated, which it is and gosec is a bit more aggressive and picking up some false positives 
