### PR TITLE
fix: add force object to automation config replicaset object

### DIFF
--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -236,6 +236,11 @@ type ReplicaSet struct {
 	Members                            []Member                `json:"members"`
 	Settings                           *map[string]interface{} `json:"settings,omitempty"`
 	WriteConcernMajorityJournalDefault string                  `json:"writeConcernMajorityJournalDefault,omitempty"`
+	Force                              Force                   `json:"force,omitempty"`
+}
+
+type Force struct {
+	CurrentVersion int `json:"currentVersion,omitempty"`
 }
 
 // TLS defines TLS parameters for Net.

--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -236,11 +236,11 @@ type ReplicaSet struct {
 	Members                            []Member                `json:"members"`
 	Settings                           *map[string]interface{} `json:"settings,omitempty"`
 	WriteConcernMajorityJournalDefault string                  `json:"writeConcernMajorityJournalDefault,omitempty"`
-	Force                              Force                   `json:"force,omitempty"`
+	Force                              *Force                  `json:"force,omitempty"`
 }
 
 type Force struct {
-	CurrentVersion int `json:"currentVersion,omitempty"`
+	CurrentVersion int `json:"currentVersion"`
 }
 
 // TLS defines TLS parameters for Net.

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -363,7 +363,7 @@ func TestAutomation_GetConfig(t *testing.T) {
 					},
 				},
 				Settings: &map[string]interface{}{},
-				Force:    Force{CurrentVersion: -1},
+				Force:    &Force{CurrentVersion: -1},
 			},
 		},
 		Version: 1,

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -173,7 +173,10 @@ const jsonBlob = `{
       "votes" : 1
     } ],
     "protocolVersion" : "1",
-    "settings" : { }
+    "settings" : { },
+	"force": { 
+		"currentVersion": -1
+	}
   } ],
   "version" : 1
 }`
@@ -360,6 +363,7 @@ func TestAutomation_GetConfig(t *testing.T) {
 					},
 				},
 				Settings: &map[string]interface{}{},
+				Force:    Force{CurrentVersion: -1},
 			},
 		},
 		Version: 1,


### PR DESCRIPTION
## Proposed changes

Adds Force property to `opsmngr.AutomationConfig.ReplicaSets`

Closes #130 

## Checklist


- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

Simple change to add a parameter to existing structures used for API calls.