### PR TITLE
fix: clean up close body workaround

### DIFF
--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -342,20 +342,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		c.onRequestCompleted(req, resp)
 	}
 
-	defer func() {
-		// Ensure the response body is fully read and closed
-		// before we reconnect, so that we reuse the same TCP connection.
-		// Close the previous response's body. But read at least some of
-		// the body so if it's small the underlying TCP connection will be
-		// re-used. No need to check for errors: if it fails, the Transport
-		// won't reuse it anyway.
-		const maxBodySlurpSize = 2 << 10
-		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
-			_, _ = io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
-		}
-
-		resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 
 	response := &Response{Response: resp}
 


### PR DESCRIPTION
## Proposed changes

This workaround was a fix around older versions of go which is no longer needed 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

