### PR TITLE
fix: Change backup options to interfaces

### DIFF
--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -357,8 +357,8 @@ type Process struct {
 	AuthSchemaVersion                          int                `json:"authSchemaVersion,omitempty"`
 	BackupPITRestoreType                       string             `json:"backupPitRestoreType,omitempty"`
 	BackupRestoreCertificateValidationHostname string             `json:"backupRestoreCertificateValidationHostname,omitempty"`
-	BackupRestoreCheckpointTimestamp           string             `json:"backupRestoreCheckpointTimestamp,omitempty"`
-	BackupRestoreDesiredTime                   string             `json:"backupRestoreDesiredTime,omitempty"`
+	BackupRestoreCheckpointTimestamp           interface{}        `json:"backupRestoreCheckpointTimestamp,omitempty"`
+	BackupRestoreDesiredTime                   interface{}        `json:"backupRestoreDesiredTime,omitempty"`
 	BackupRestoreFilterList                    interface{}        `json:"backupRestoreFilterList,omitempty"`
 	BackupRestoreJobID                         string             `json:"backupRestoreJobId,omitempty"`
 	BackupRestoreURL                           string             `json:"backupRestoreUrl,omitempty"`

--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -50,7 +50,7 @@ type Client struct {
 	BaseURL   *url.URL
 	UserAgent string
 
-	// copy raw atlas server response to the Response struct
+	// copy raw server response to the Response struct
 	withRaw bool
 
 	Organizations          OrganizationsService


### PR DESCRIPTION
## Proposed changes

This properties are not string and failing to be deserialized, moving to interface for now

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

