### PR TITLE
CLOUDP-114669: Automatically add trailing slash to the URL

### DIFF
--- a/opsmngr/opsmngr.go
+++ b/opsmngr/opsmngr.go
@@ -275,7 +275,7 @@ func (c *Client) NewPlainRequest(ctx context.Context, method, urlStr string) (*h
 
 func (c *Client) newRequest(ctx context.Context, urlStr, method string, body interface{}) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
-		return nil, fmt.Errorf("base URL must have a trailing slash, but %q does not", c.BaseURL)
+		c.BaseURL.Path += "/"
 	}
 	rel, err := url.Parse(urlStr)
 	if err != nil {

--- a/opsmngr/opsmngr_test.go
+++ b/opsmngr/opsmngr_test.go
@@ -209,12 +209,12 @@ func TestNewRequest_emptyBody(t *testing.T) {
 	}
 }
 
-func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
+func TestNewRequest_noErrorForNoTrailingSlash(t *testing.T) {
 	tests := []struct {
 		rawurl    string
 		wantError bool
 	}{
-		{rawurl: "https://example.com/api/v1", wantError: true},
+		{rawurl: "https://example.com/api/v1", wantError: false},
 		{rawurl: "https://example.com/api/v1/", wantError: false},
 	}
 	c := NewClient(nil)
@@ -228,6 +228,32 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewRequest returned unexpected error: %v.", err)
+		}
+	}
+}
+
+func TestNewRequest_correctURLWithNoTrailingSlash(t *testing.T) {
+	tests := []struct {
+		rawURL      string
+		expectedURL string
+	}{
+		{rawURL: "http://test.com", expectedURL: "http://test.com/"},
+		{rawURL: "http://home.base.com/", expectedURL: "http://home.base.com/"},
+	}
+
+	c := NewClient(nil)
+	for _, test := range tests {
+		u, err := url.Parse(test.rawURL)
+		if err != nil {
+			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+		}
+		c.BaseURL = u
+		req, err := c.NewRequest(ctx, http.MethodGet, "", nil)
+		if err != nil {
+			t.Fatalf("NewRequest return unexpected error: %v.", err)
+		}
+		if req.URL.String() != test.expectedURL {
+			t.Fatalf("Incorrectly added trailing slash. Expected: %v; Got: %v.", test.expectedURL, req.URL.String())
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-114669

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
Original PR: https://github.com/mongodb/go-client-mongodb-atlas/pull/281