### PR TITLE
fix: allow empty policies for feature controls

### DIFF
--- a/opsmngr/feature_control_policies.go
+++ b/opsmngr/feature_control_policies.go
@@ -46,7 +46,7 @@ type FeaturePolicy struct {
 	Created                  string                    `json:"created,omitempty"`
 	Updated                  string                    `json:"updated,omitempty"`
 	ExternalManagementSystem *ExternalManagementSystem `json:"externalManagementSystem,omitempty"`
-	Policies                 []*Policy                 `json:"policies,omitempty"`
+	Policies                 []*Policy                 `json:"policies"`
 }
 
 // ExternalManagementSystem contains parameters for the external system that manages this Ops Manager Project.


### PR DESCRIPTION
## Proposed changes

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments
To disable feature controls you need to pass an empty list, since we had ignore empty this were not being serialized and some versions of ops managers will error with 500 when null 