### PR TITLE
feat: add suspend automation method

### DIFF
--- a/atmcfg/atmcfg_test.go
+++ b/atmcfg/atmcfg_test.go
@@ -22,25 +22,6 @@ import (
 
 const clusterName = "cluster_1"
 
-func TestRemoveByClusterName(t *testing.T) {
-	t.Run("replica set", func(t *testing.T) {
-		config := automationConfigWithOneReplicaSet(clusterName, false)
-
-		RemoveByClusterName(config, clusterName)
-		if len(config.Processes) != 0 {
-			t.Errorf("Got = %#v, want = 0", len(config.Processes))
-		}
-	})
-	t.Run("sharded cluster", func(t *testing.T) {
-		config := automationConfigWithOneShardedCluster(clusterName, false)
-
-		RemoveByClusterName(config, clusterName)
-		if len(config.Processes) != 0 {
-			t.Errorf("Got = %#v, want = 0", len(config.Processes))
-		}
-	})
-}
-
 func TestIsGoalState(t *testing.T) {
 	tests := []struct {
 		name string

--- a/atmcfg/fixtures.go
+++ b/atmcfg/fixtures.go
@@ -47,6 +47,7 @@ func automationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 				AuthSchemaVersion:           authSchemaVersion,
 				Name:                        name + "_0",
 				Disabled:                    disabled,
+				ManualMode:                  disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "host0",
 				LogRotate: &opsmngr.LogRotate{
@@ -103,6 +104,7 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 				AuthSchemaVersion:           authSchemaVersion,
 				Name:                        name + "_shard_0_0",
 				Disabled:                    disabled,
+				ManualMode:                  disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "host0",
 				LogRotate: &opsmngr.LogRotate{
@@ -134,6 +136,7 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 				AuthSchemaVersion:           authSchemaVersion,
 				Name:                        name + "_configRS_0",
 				Disabled:                    disabled,
+				ManualMode:                  disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "host2",
 				LogRotate: &opsmngr.LogRotate{
@@ -160,6 +163,7 @@ func automationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 				Cluster:                     name,
 				Name:                        name + "_mongos_0",
 				Disabled:                    disabled,
+				ManualMode:                  disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "host1",
 				LogRotate: &opsmngr.LogRotate{

--- a/atmcfg/remove.go
+++ b/atmcfg/remove.go
@@ -1,0 +1,70 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atmcfg
+
+import (
+	"go.mongodb.org/ops-manager/opsmngr"
+	"go.mongodb.org/ops-manager/search"
+)
+
+// RemoveByClusterName removes a cluster and its associated processes from the config.
+// This won't shutdown any running process.
+func RemoveByClusterName(out *opsmngr.AutomationConfig, name string) {
+	// This value may not be present and is mandatory
+	if out.Auth.DeploymentAuthMechanisms == nil {
+		out.Auth.DeploymentAuthMechanisms = make([]string, 0)
+	}
+	removeByReplicaSetName(out, name)
+	removeByShardName(out, name)
+}
+
+func removeByReplicaSetName(out *opsmngr.AutomationConfig, name string) {
+	i, found := search.ReplicaSets(out.ReplicaSets, func(rs *opsmngr.ReplicaSet) bool {
+		return rs.ID == name
+	})
+	if found {
+		rs := out.ReplicaSets[i]
+		out.ReplicaSets = append(out.ReplicaSets[:i], out.ReplicaSets[i+1:]...)
+		for _, m := range rs.Members {
+			for k, p := range out.Processes {
+				if p.Name == m.Host {
+					out.Processes = append(out.Processes[:k], out.Processes[k+1:]...)
+				}
+			}
+		}
+	}
+}
+
+func removeByShardName(out *opsmngr.AutomationConfig, name string) {
+	i, found := search.ShardingConfig(out.Sharding, func(rs *opsmngr.ShardingConfig) bool {
+		return rs.Name == name
+	})
+	if found {
+		s := out.Sharding[i]
+		out.Sharding = append(out.Sharding[:i], out.Sharding[i+1:]...)
+		// remove shards
+		for _, rs := range s.Shards {
+			removeByReplicaSetName(out, rs.ID)
+		}
+		// remove config rs
+		removeByReplicaSetName(out, s.ConfigServerReplica)
+		// remove mongos
+		for j := range out.Processes {
+			if out.Processes[j].Cluster == name {
+				out.Processes = append(out.Processes[:j], out.Processes[j+1:]...)
+			}
+		}
+	}
+}

--- a/atmcfg/remove_test.go
+++ b/atmcfg/remove_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atmcfg
+
+import "testing"
+
+func TestRemoveByClusterName(t *testing.T) {
+	t.Run("replica set", func(t *testing.T) {
+		config := automationConfigWithOneReplicaSet(clusterName, false)
+
+		RemoveByClusterName(config, clusterName)
+		if len(config.Processes) != 0 {
+			t.Errorf("Got = %#v, want = 0", len(config.Processes))
+		}
+	})
+	t.Run("sharded cluster", func(t *testing.T) {
+		config := automationConfigWithOneShardedCluster(clusterName, false)
+
+		RemoveByClusterName(config, clusterName)
+		if len(config.Processes) != 0 {
+			t.Errorf("Got = %#v, want = 0", len(config.Processes))
+		}
+	})
+}

--- a/atmcfg/suspend.go
+++ b/atmcfg/suspend.go
@@ -63,35 +63,39 @@ func setManualModeByReplicaSetNameAndProcesses(out *opsmngr.AutomationConfig, na
 	i, found := search.ReplicaSets(out.ReplicaSets, func(rs *opsmngr.ReplicaSet) bool {
 		return rs.ID == name
 	})
-	if found {
-		rs := out.ReplicaSets[i]
-		for _, m := range rs.Members {
-			for k, p := range out.Processes {
-				if p.Name == m.Host {
-					setManualMode(out.Processes[k], processesMap, manualMode)
-				}
+	if !found {
+		return
+	}
+	rs := out.ReplicaSets[i]
+	for _, m := range rs.Members {
+		for k, p := range out.Processes {
+			if p.Name == m.Host {
+				setManualMode(out.Processes[k], processesMap, manualMode)
 			}
 		}
 	}
+
 }
 
 func setManualModeByShardNameAndProcesses(out *opsmngr.AutomationConfig, name string, processesMap map[string]bool, manualMode bool) {
 	i, found := search.ShardingConfig(out.Sharding, func(s *opsmngr.ShardingConfig) bool {
 		return s.Name == name
 	})
-	if found {
-		s := out.Sharding[i]
-		// manual mode per shards
-		for _, rs := range s.Shards {
-			setManualModeByReplicaSetNameAndProcesses(out, rs.ID, processesMap, manualMode)
-		}
-		// manual mode config rs
-		setManualModeByReplicaSetNameAndProcesses(out, s.ConfigServerReplica, processesMap, manualMode)
-		// manual mode mongos
-		for j := range out.Processes {
-			if out.Processes[j].Cluster == name {
-				setManualMode(out.Processes[j], processesMap, manualMode)
-			}
+	if !found {
+		return
+	}
+
+	s := out.Sharding[i]
+	// manual mode per shards
+	for _, rs := range s.Shards {
+		setManualModeByReplicaSetNameAndProcesses(out, rs.ID, processesMap, manualMode)
+	}
+	// manual mode config rs
+	setManualModeByReplicaSetNameAndProcesses(out, s.ConfigServerReplica, processesMap, manualMode)
+	// manual mode mongos
+	for j := range out.Processes {
+		if out.Processes[j].Cluster == name {
+			setManualMode(out.Processes[j], processesMap, manualMode)
 		}
 	}
 }

--- a/atmcfg/suspend.go
+++ b/atmcfg/suspend.go
@@ -1,0 +1,116 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atmcfg // Package atmcfg import "go.mongodb.org/ops-manager/atmcfg"
+
+import (
+	"fmt"
+
+	"go.mongodb.org/ops-manager/opsmngr"
+	"go.mongodb.org/ops-manager/search"
+)
+
+// Suspend suspends automation for all processes.
+func Suspend(out *opsmngr.AutomationConfig, clusterName string) {
+	setManualModeByClusterName(out, clusterName, true)
+}
+
+// SuspendProcessesByClusterName suspends automation for the entire cluster or its processes.
+// Processes are provided in the format {"hostname:port","hostname2:port2"}.
+func SuspendProcessesByClusterName(out *opsmngr.AutomationConfig, clusterName string, processes []string) error {
+	if len(processes) == 0 {
+		Suspend(out, clusterName)
+		return nil
+	}
+	return suspendProcesses(out, clusterName, processes)
+}
+
+// suspendProcesses suspends automation for the processes.
+// Processes are provided in the format {"hostname:port","hostname2:port2"}.
+func suspendProcesses(out *opsmngr.AutomationConfig, clusterName string, processes []string) error {
+	processesMap := newProcessMap(processes)
+	setManualModeByNameAndProcesses(out, clusterName, processesMap, true)
+
+	return newProcessNotFoundError(clusterName, processesMap)
+}
+
+func setManualModeByClusterName(out *opsmngr.AutomationConfig, name string, manualMode bool) {
+	newDeploymentAuthMechanisms(out)
+	setManualModeByReplicaSetName(out, name, manualMode)
+	setManualModeByShardName(out, name, manualMode)
+}
+
+func setManualModeByReplicaSetName(out *opsmngr.AutomationConfig, name string, manualMode bool) {
+	setManualModeByReplicaSetNameAndProcesses(out, name, nil, manualMode)
+}
+
+func setManualModeByShardName(out *opsmngr.AutomationConfig, name string, manualMode bool) {
+	setManualModeByShardNameAndProcesses(out, name, nil, manualMode)
+}
+
+func setManualModeByReplicaSetNameAndProcesses(out *opsmngr.AutomationConfig, name string, processesMap map[string]bool, manualMode bool) {
+	i, found := search.ReplicaSets(out.ReplicaSets, func(rs *opsmngr.ReplicaSet) bool {
+		return rs.ID == name
+	})
+	if found {
+		rs := out.ReplicaSets[i]
+		for _, m := range rs.Members {
+			for k, p := range out.Processes {
+				if p.Name == m.Host {
+					setManualMode(out.Processes[k], processesMap, manualMode)
+				}
+			}
+		}
+	}
+}
+
+func setManualModeByShardNameAndProcesses(out *opsmngr.AutomationConfig, name string, processesMap map[string]bool, manualMode bool) {
+	i, found := search.ShardingConfig(out.Sharding, func(s *opsmngr.ShardingConfig) bool {
+		return s.Name == name
+	})
+	if found {
+		s := out.Sharding[i]
+		// manual mode per shards
+		for _, rs := range s.Shards {
+			setManualModeByReplicaSetNameAndProcesses(out, rs.ID, processesMap, manualMode)
+		}
+		// manual mode config rs
+		setManualModeByReplicaSetNameAndProcesses(out, s.ConfigServerReplica, processesMap, manualMode)
+		// manual mode mongos
+		for j := range out.Processes {
+			if out.Processes[j].Cluster == name {
+				setManualMode(out.Processes[j], processesMap, manualMode)
+			}
+		}
+	}
+}
+
+func setManualMode(process *opsmngr.Process, processesMap map[string]bool, manualMode bool) {
+	if len(processesMap) == 0 {
+		process.ManualMode = manualMode
+		return
+	}
+
+	key := fmt.Sprintf("%s:%d", process.Hostname, process.Args26.NET.Port)
+	if _, ok := processesMap[key]; ok {
+		process.ManualMode = manualMode
+		processesMap[key] = true
+	}
+}
+
+func setManualModeByNameAndProcesses(out *opsmngr.AutomationConfig, clusterName string, processesMap map[string]bool, manualMode bool) {
+	newDeploymentAuthMechanisms(out)
+	setManualModeByReplicaSetNameAndProcesses(out, clusterName, processesMap, manualMode)
+	setManualModeByShardNameAndProcesses(out, clusterName, processesMap, manualMode)
+}

--- a/atmcfg/suspend.go
+++ b/atmcfg/suspend.go
@@ -74,7 +74,6 @@ func setManualModeByReplicaSetNameAndProcesses(out *opsmngr.AutomationConfig, na
 			}
 		}
 	}
-
 }
 
 func setManualModeByShardNameAndProcesses(out *opsmngr.AutomationConfig, name string, processesMap map[string]bool, manualMode bool) {

--- a/atmcfg/suspend_test.go
+++ b/atmcfg/suspend_test.go
@@ -1,0 +1,110 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atmcfg
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSuspend(t *testing.T) {
+	t.Run("replica set", func(t *testing.T) {
+		config := automationConfigWithOneReplicaSet(clusterName, false)
+		Suspend(config, clusterName)
+		if !config.Processes[0].ManualMode {
+			t.Errorf("Got = %#v, want = %#v", config.Processes[0].Disabled, true)
+		}
+	})
+	t.Run("sharded cluster", func(t *testing.T) {
+		config := automationConfigWithOneShardedCluster(clusterName, false)
+		Suspend(config, clusterName)
+		for i := range config.Processes {
+			if !config.Processes[i].ManualMode {
+				t.Errorf("Got = %#v, want = %#v", config.Processes[i].Disabled, true)
+			}
+		}
+	})
+}
+
+func TestSuspendProcessesByClusterName(t *testing.T) {
+	t.Run("replica set", func(t *testing.T) {
+		config := automationConfigWithOneReplicaSet(clusterName, false)
+		err := SuspendProcessesByClusterName(config, clusterName, []string{"host0:27017"})
+		if err != nil {
+			t.Fatalf("ShutdownProcessesByClusterName() returned an unexpected error: %v", err)
+		}
+		if !config.Processes[0].ManualMode {
+			t.Errorf("Got = %#v, want = %#v", config.Processes[0].Disabled, true)
+		}
+	})
+	t.Run("sharded cluster - one process", func(t *testing.T) {
+		config := automationConfigWithOneShardedCluster(clusterName, false)
+		err := SuspendProcessesByClusterName(config, clusterName, []string{"host2:27018"})
+		if err != nil {
+			t.Fatalf("ShutdownProcessesByClusterName() returned an unexpected error: %v", err)
+		}
+
+		if config.Processes[0].ManualMode {
+			t.Errorf("Got = %#v, want = %#v", config.Processes[0].Disabled, false)
+		}
+
+		if !config.Processes[1].ManualMode {
+			t.Errorf("Got = %#v, want = %#v", config.Processes[1].Disabled, true)
+		}
+	})
+	t.Run("sharded cluster - two processes", func(t *testing.T) {
+		config := automationConfigWithOneShardedCluster(clusterName, false)
+		err := SuspendProcessesByClusterName(config, clusterName, []string{"host2:27018", "host0:27017"})
+		if err != nil {
+			t.Fatalf("ShutdownProcessesByClusterName() returned an unexpected error: %v", err)
+		}
+
+		if !config.Processes[0].ManualMode {
+			t.Errorf("Got = %#v, want = %#v", config.Processes[0].Disabled, true)
+		}
+
+		if !config.Processes[1].ManualMode {
+			t.Errorf("Got = %#v, want = %#v", config.Processes[1].Disabled, true)
+		}
+	})
+	t.Run("shutdown entire sharded cluster", func(t *testing.T) {
+		config := automationConfigWithOneShardedCluster(clusterName, true)
+
+		err := SuspendProcessesByClusterName(config, clusterName, nil)
+		if err != nil {
+			t.Fatalf("ShutdownProcessesByClusterName() returned an unexpected error: %v", err)
+		}
+
+		for i := range config.Processes {
+			if !config.Processes[i].ManualMode {
+				t.Errorf("Got = %#v, want = %#v", config.Processes[i].Disabled, true)
+			}
+		}
+	})
+	t.Run("provide a process that does not exist", func(t *testing.T) {
+		config := automationConfigWithOneShardedCluster(clusterName, true)
+
+		err := SuspendProcessesByClusterName(config, clusterName, []string{"hostTest:21021"})
+		if !errors.Is(err, ErrProcessNotFound) {
+			t.Fatalf("Got = %#v, want = %#v", err, ErrProcessNotFound)
+		}
+
+		for i := range config.Processes {
+			if !config.Processes[i].ManualMode {
+				t.Errorf("Got = %#v, want = %#v", config.Processes[i].Disabled, false)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Proposed changes

Add a method to suspend automation for a cluster, or processes of a cluster 

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Follows the same patters we have used for actions like restart, compact space or similar
