### PR TITLE
task: drop go 1.17 support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: lint
         uses: golangci/golangci-lint-action@v3.3.0
         with:
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.17
           - 1.18
           - 1.19
     steps:


### PR DESCRIPTION
Drop support for 1.17 which is in line with our support policy of two latets major releases to unblock pointy lib upgrade