### PR TITLE
CLOUDP-274340: Move to Auth version API

### DIFF
--- a/opsmngr/service_version.go
+++ b/opsmngr/service_version.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 )
 
-const versionPath = "api/private/unauth/version"
+const versionPath = "api/public/v1.0/software/version"
 
 // ServiceVersionService is an interface for the version private endpoint of the MongoDB Ops Manager API.
 //

--- a/opsmngr/service_version_test.go
+++ b/opsmngr/service_version_test.go
@@ -24,7 +24,7 @@ func TestServiceVersionService_Get(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/api/private/unauth/version", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/public/v1.0/software/version", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, "someGitHash")
 	})


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes
In order to close a security concern in Ops Manager, we need to move the unauth/version API to public/v1.0/software/version and require API keys to be able to access it.

_Jira ticket:_ CLOUDP-274340

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
