### PR TITLE
fix: add missing prometheus config to AutomationConfig

### DIFF
--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -88,6 +88,7 @@ type AutomationConfig struct {
 	Mongots                   []*map[string]interface{} `json:"mongots"`
 	Options                   *map[string]interface{}   `json:"options"`
 	Processes                 []*Process                `json:"processes"`
+	Prometheus                *Prometheus               `json:"prometheus,omitempty"`
 	ReplicaSets               []*ReplicaSet             `json:"replicaSets"`
 	Roles                     []*map[string]interface{} `json:"roles"`
 	Sharding                  []*ShardingConfig         `json:"sharding"`
@@ -441,4 +442,18 @@ type Process struct {
 	Plan                                       []string           `json:"plan,omitempty"`
 	ProcessType                                string             `json:"processType,omitempty"`
 	Version                                    string             `json:"version,omitempty"`
+}
+
+type Prometheus struct {
+	Enabled        bool   `json:"enabled"`
+	Username       string `json:"username"`
+	Password       string `json:"password,omitempty"`
+	PasswordHash   string `json:"passwordHash,omitempty"`
+	PasswordSalt   string `json:"passwordSalt,omitempty"`
+	Scheme         string `json:"scheme"`
+	TLSPemPath     string `json:"tlsPemPath"`
+	TLSPemPassword string `json:"tlsPemPassword"`
+	Mode           string `json:"mode"`
+	ListenAddress  string `json:"listenAddress"`
+	MetricsPath    string `json:"metricsPath"`
 }

--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -445,15 +445,16 @@ type Process struct {
 }
 
 type Prometheus struct {
-	Enabled        bool   `json:"enabled"`
-	Username       string `json:"username"`
-	Password       string `json:"password,omitempty"`
-	PasswordHash   string `json:"passwordHash,omitempty"`
-	PasswordSalt   string `json:"passwordSalt,omitempty"`
-	Scheme         string `json:"scheme"`
-	TLSPemPath     string `json:"tlsPemPath"`
-	TLSPemPassword string `json:"tlsPemPassword"`
-	Mode           string `json:"mode"`
-	ListenAddress  string `json:"listenAddress"`
-	MetricsPath    string `json:"metricsPath"`
+	Enabled              bool   `json:"enabled"`
+	Username             string `json:"username"`
+	PasswordHash         string `json:"passwordHash,omitempty"`
+	PasswordSalt         string `json:"passwordSalt,omitempty"`
+	Scheme               string `json:"scheme"`
+	TLSPemPath           string `json:"tlsPemPath"`
+	TLSPemPassword       string `json:"tlsPemPassword"`
+	Mode                 string `json:"mode"`
+	ListenAddress        string `json:"listenAddress"`
+	MetricsPath          string `json:"metricsPath"`
+	TokenFillRateSeconds int    `json:"tokenFillRateSeconds"`
+	BurstTokenCount      int    `json:"burstTokenCount"`
 }

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -896,12 +896,14 @@ func TestAutomation_UpdatePrometheusConfig(t *testing.T) {
 
 	updateRequest := &AutomationConfig{
 		Prometheus: &Prometheus{
-			Enabled:       true,
-			ListenAddress: "0.0.0.0:9216",
-			MetricsPath:   "/metrics",
-			Mode:          "opsManager",
-			Scheme:        "http",
-			Username:      "user",
+			Enabled:              true,
+			ListenAddress:        "0.0.0.0:9216",
+			MetricsPath:          "/metrics",
+			Mode:                 "opsManager",
+			Scheme:               "http",
+			Username:             "user",
+			TokenFillRateSeconds: 1,
+			BurstTokenCount:      1,
 		},
 		Auth: Auth{
 			AuthoritativeSet:  false,
@@ -917,14 +919,16 @@ func TestAutomation_UpdatePrometheusConfig(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/groups/%s/automationConfig", projectID), func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
 			"prometheus": map[string]interface{}{
-				"enabled":        true,
-				"listenAddress":  "0.0.0.0:9216",
-				"metricsPath":    "/metrics",
-				"mode":           "opsManager",
-				"scheme":         "http",
-				"tlsPemPassword": "",
-				"tlsPemPath":     "",
-				"username":       "user",
+				"enabled":              true,
+				"listenAddress":        "0.0.0.0:9216",
+				"metricsPath":          "/metrics",
+				"mode":                 "opsManager",
+				"scheme":               "http",
+				"tlsPemPassword":       "",
+				"tlsPemPath":           "",
+				"username":             "user",
+				"tokenFillRateSeconds": 1.0,
+				"burstTokenCount":      1.0,
 			},
 			"auth": map[string]interface{}{
 				"authoritativeSet":     false,

--- a/opsmngr/automation_config_test.go
+++ b/opsmngr/automation_config_test.go
@@ -848,3 +848,126 @@ func TestAutomation_Sharding(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestAutomation_GetPrometheusConfig(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/groups/%s/automationConfig", projectID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+  "prometheus" : {
+    "enabled": true,
+    "listenAddress": "0.0.0.0:9216",
+    "metricsPath": "/metrics",
+    "mode": "opsManager",
+    "passwordHash": "",
+    "passwordSalt": "",
+    "scheme": "http",
+    "tlsPemPassword": "",
+    "tlsPemPath": "",
+    "username": "user"
+  }}`)
+	})
+
+	config, _, err := client.Automation.GetConfig(ctx, projectID)
+	if err != nil {
+		t.Fatalf("Automation.GetConfig returned error: %v", err)
+	}
+
+	expected := &AutomationConfig{
+		Prometheus: &Prometheus{
+			Enabled:       true,
+			ListenAddress: "0.0.0.0:9216",
+			MetricsPath:   "/metrics",
+			Mode:          "opsManager",
+			Scheme:        "http",
+			Username:      "user",
+		},
+	}
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestAutomation_UpdatePrometheusConfig(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	updateRequest := &AutomationConfig{
+		Prometheus: &Prometheus{
+			Enabled:       true,
+			ListenAddress: "0.0.0.0:9216",
+			MetricsPath:   "/metrics",
+			Mode:          "opsManager",
+			Scheme:        "http",
+			Username:      "user",
+		},
+		Auth: Auth{
+			AuthoritativeSet:  false,
+			AutoAuthMechanism: "MONGODB-CR",
+			Disabled:          true,
+			UsersWanted: []*MongoDBUser{
+				{
+					Database: "admin",
+				},
+			},
+		},
+	}
+	mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/groups/%s/automationConfig", projectID), func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"prometheus": map[string]interface{}{
+				"enabled":        true,
+				"listenAddress":  "0.0.0.0:9216",
+				"metricsPath":    "/metrics",
+				"mode":           "opsManager",
+				"scheme":         "http",
+				"tlsPemPassword": "",
+				"tlsPemPath":     "",
+				"username":       "user",
+			},
+			"auth": map[string]interface{}{
+				"authoritativeSet":     false,
+				"autoAuthMechanism":    "MONGODB-CR",
+				"autoAuthRestrictions": interface{}(nil),
+				"disabled":             true,
+				"usersDeleted":         interface{}(nil),
+				"usersWanted": []interface{}{
+					map[string]interface{}{
+						"authenticationRestrictions": interface{}(nil),
+						"db":                         "admin",
+						"roles":                      interface{}(nil),
+						"user":                       "",
+					},
+				},
+			},
+			"backupVersions":       interface{}(nil),
+			"balancer":             interface{}(nil),
+			"cpsModules":           interface{}(nil),
+			"indexConfigs":         interface{}(nil),
+			"mongosqlds":           interface{}(nil),
+			"mongots":              interface{}(nil),
+			"onlineArchiveModules": interface{}(nil),
+			"options":              interface{}(nil),
+			"processes":            interface{}(nil),
+			"replicaSets":          interface{}(nil),
+			"roles":                interface{}(nil),
+			"sharding":             interface{}(nil),
+		}
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+		t.Logf("v=%#v\n", v)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
+		}
+		_, _ = fmt.Fprint(w, `{}`)
+	})
+
+	_, err := client.Automation.UpdateConfig(ctx, projectID, updateRequest)
+	if err != nil {
+		t.Fatalf("Automation.UpdateConfig returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Proposed changes
**Current behaviour:**
Prometheus configuration is missing from the AutomationConfig when we get it via the opsmngr [GetConfig](https://github.com/mongodb/go-client-mongodb-ops-manager/blob/c93a707acdb1090bdd51c05f5a5a9ba69ec6a4dc/opsmngr/automation_config.go#L24) call. We can see it is missing from [the AutomationConfig struct](https://github.com/mongodb/go-client-mongodb-ops-manager/blob/c93a707acdb1090bdd51c05f5a5a9ba69ec6a4dc/opsmngr/automation_config.go#L68). However, [prometheus configuration is present when we get it directly from the opsmanager API](https://www.mongodb.com/docs/ops-manager/current/reference/api/automation-config/get-automation-config/).
**Proposed behaviour:**
Prometheus configuration will be properly handled and returned in opsmngr GetConfig and UpdateConfig calls.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code