### PR TITLE
CLOUDP-295783: Make backupRestoreIsSuccessiveUpgrade a pointer

### DIFF
--- a/opsmngr/automation_config.go
+++ b/opsmngr/automation_config.go
@@ -411,7 +411,7 @@ type Process struct {
 	BackupRestoreFilterList                    interface{}        `json:"backupRestoreFilterList,omitempty"`
 	BackupRestoreJobID                         string             `json:"backupRestoreJobId,omitempty"`
 	BackupRestoreURL                           string             `json:"backupRestoreUrl,omitempty"`
-	BackupRestoreIsSuccessiveUpgrade           bool               `json:"backupRestoreIsSuccessiveUpgrade,omitempty"`
+	BackupRestoreIsSuccessiveUpgrade           *bool              `json:"backupRestoreIsSuccessiveUpgrade,omitempty"`
 	BackupRestoreOplogBaseURL                  string             `json:"backupRestoreOplogBaseUrl,omitempty"`
 	BackupRestoreOplog                         interface{}        `json:"backupRestoreOplog,omitempty"`
 	BackupRestoreRsVersion                     *int               `json:"backupRestoreRsVersion,omitempty"`


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Ops Manager Go Client!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/go-client-mongodb-ops-manager/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

- Make `backupRestoreIsSuccessiveUpgrade` field a pointer so that `omitempty` doesn't remove it from the payload when the value is `false`
- *Note*: This is a _breaking_ change, but nobody should be using the field, as it's for internal use.

_Jira ticket:_ [CLOUDP-295783](https://jira.mongodb.org/browse/CLOUDP-295783)

