### PR TITLE
Adding Organization Update Method

### DIFF
--- a/opsmngr/organizations.go
+++ b/opsmngr/organizations.go
@@ -239,25 +239,25 @@ func (s *OrganizationsServiceOp) Delete(ctx context.Context, orgID string) (*Res
 //
 // See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/organization-rename/
 func (s *OrganizationsServiceOp) Update(ctx context.Context, orgID string, updateRequest *Organization) (*Organization, *Response, error) {
-    if orgID == "" {
-        return nil, nil, NewArgError("orgID", "must be set")
-    }
-    if updateRequest == nil {
-        return nil, nil, NewArgError("updateRequest", "cannot be nil")
-    }
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
 
-    path := fmt.Sprintf("%s/%s", orgsBasePath, orgID)
+	path := fmt.Sprintf("%s/%s", orgsBasePath, orgID)
 
-    req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-    if err != nil {
-        return nil, nil, err
-    }
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    root := new(Organization)
-    resp, err := s.Client.Do(ctx, req, root)
-    if err != nil {
-        return nil, resp, err
-    }
+	root := new(Organization)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
 
-    return root, resp, err
+	return root, resp, err
 }

--- a/opsmngr/organizations.go
+++ b/opsmngr/organizations.go
@@ -33,6 +33,7 @@ type OrganizationsService interface {
 	Get(context.Context, string) (*Organization, *Response, error)
 	Projects(context.Context, string, *ProjectsListOptions) (*Projects, *Response, error)
 	Create(context.Context, *Organization) (*Organization, *Response, error)
+	Update(context.Context, string, *Organization) (*Organization, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	Invitations(context.Context, string, *InvitationOptions) ([]*Invitation, *Response, error)
 	Invitation(context.Context, string, string) (*Invitation, *Response, error)
@@ -232,4 +233,31 @@ func (s *OrganizationsServiceOp) Delete(ctx context.Context, orgID string) (*Res
 	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
+}
+
+// Update updates an organization.
+//
+// See more: https://docs.opsmanager.mongodb.com/current/reference/api/organizations/organization-rename/
+func (s *OrganizationsServiceOp) Update(ctx context.Context, orgID string, updateRequest *Organization) (*Organization, *Response, error) {
+    if orgID == "" {
+        return nil, nil, NewArgError("orgID", "must be set")
+    }
+    if updateRequest == nil {
+        return nil, nil, NewArgError("updateRequest", "cannot be nil")
+    }
+
+    path := fmt.Sprintf("%s/%s", orgsBasePath, orgID)
+
+    req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+    if err != nil {
+        return nil, nil, err
+    }
+
+    root := new(Organization)
+    resp, err := s.Client.Do(ctx, req, root)
+    if err != nil {
+        return nil, resp, err
+    }
+
+    return root, resp, err
 }

--- a/opsmngr/organizations_test.go
+++ b/opsmngr/organizations_test.go
@@ -363,3 +363,44 @@ func TestOrganizations_Delete(t *testing.T) {
 		t.Fatalf("Organizations.Delete returned error: %v", err)
 	}
 }
+
+func TestOrganizations_Update(t *testing.T) {
+    client, mux, teardown := setup()
+    defer teardown()
+
+    updateRequest := &Organization{
+        Name: "RenamedOrg",
+    }
+
+    mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/orgs/%s", orgID), func(w http.ResponseWriter, r *http.Request) {
+        testMethod(t, r, http.MethodPatch)
+        _, _ = fmt.Fprint(w, `{
+            "id": "5a0a1e7e0f2912c554081adc",
+            "links": [{
+                "href": "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554081adc",
+                "rel": "self"
+            }],
+            "name": "RenamedOrg"
+        }`)
+    })
+
+    org, _, err := client.Organizations.Update(ctx, orgID, updateRequest)
+    if err != nil {
+        t.Fatalf("Organizations.Update returned error: %v", err)
+    }
+
+    expected := &Organization{
+        ID: orgID,
+        Links: []*Link{
+            {
+                Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554081adc",
+                Rel:  "self",
+            },
+        },
+        Name: "RenamedOrg",
+    }
+
+    if diff := deep.Equal(org, expected); diff != nil {
+        t.Error(diff)
+    }
+}

--- a/opsmngr/organizations_test.go
+++ b/opsmngr/organizations_test.go
@@ -365,16 +365,16 @@ func TestOrganizations_Delete(t *testing.T) {
 }
 
 func TestOrganizations_Update(t *testing.T) {
-    client, mux, teardown := setup()
-    defer teardown()
+	client, mux, teardown := setup()
+	defer teardown()
 
-    updateRequest := &Organization{
-        Name: "RenamedOrg",
-    }
+	updateRequest := &Organization{
+		Name: "RenamedOrg",
+	}
 
-    mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/orgs/%s", orgID), func(w http.ResponseWriter, r *http.Request) {
-        testMethod(t, r, http.MethodPatch)
-        _, _ = fmt.Fprint(w, `{
+	mux.HandleFunc(fmt.Sprintf("/api/public/v1.0/orgs/%s", orgID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		_, _ = fmt.Fprint(w, `{
             "id": "5a0a1e7e0f2912c554081adc",
             "links": [{
                 "href": "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554081adc",
@@ -382,25 +382,25 @@ func TestOrganizations_Update(t *testing.T) {
             }],
             "name": "RenamedOrg"
         }`)
-    })
+	})
 
-    org, _, err := client.Organizations.Update(ctx, orgID, updateRequest)
-    if err != nil {
-        t.Fatalf("Organizations.Update returned error: %v", err)
-    }
+	org, _, err := client.Organizations.Update(ctx, orgID, updateRequest)
+	if err != nil {
+		t.Fatalf("Organizations.Update returned error: %v", err)
+	}
 
-    expected := &Organization{
-        ID: orgID,
-        Links: []*Link{
-            {
-                Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554081adc",
-                Rel:  "self",
-            },
-        },
-        Name: "RenamedOrg",
-    }
+	expected := &Organization{
+		ID: orgID,
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554081adc",
+				Rel:  "self",
+			},
+		},
+		Name: "RenamedOrg",
+	}
 
-    if diff := deep.Equal(org, expected); diff != nil {
-        t.Error(diff)
-    }
+	if diff := deep.Equal(org, expected); diff != nil {
+		t.Error(diff)
+	}
 }


### PR DESCRIPTION
For the ticket: https://github.com/mongodb/go-client-mongodb-ops-manager/issues/270

## Proposed changes

I added the Update function to the Organization management

Closes #270 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

